### PR TITLE
feat(agent): local ring buffer for Redis unavailability (closes #2)

### DIFF
--- a/agent/cmd/agent/main.go
+++ b/agent/cmd/agent/main.go
@@ -26,6 +26,8 @@ func main() {
 		RedisPassword: cfg.Redis.Password,
 		Stream:        cfg.Redis.Stream,
 		Debug:         cfg.Debug,
+		BufferCap:     cfg.Buffer.Capacity,
+		RetryInterval: cfg.Buffer.RetryInterval,
 	})
 	if err != nil {
 		log.Fatalf("fatal: %v", err)

--- a/agent/internal/buffer/ring.go
+++ b/agent/internal/buffer/ring.go
@@ -1,0 +1,83 @@
+package buffer
+
+import (
+	"sync"
+
+	"github.com/yuriPeixoto/maestro/agent/internal/collector"
+)
+
+// Ring is a thread-safe fixed-capacity circular buffer of metric batches.
+// When full, writing evicts the oldest entry (FIFO). It never blocks.
+type Ring struct {
+	mu       sync.Mutex
+	items    [][]collector.Metric
+	head     int // index of the oldest item
+	tail     int // index where the next item will be written
+	count    int
+	capacity int
+}
+
+// New creates a Ring with the given capacity. Panics if capacity < 1.
+func New(capacity int) *Ring {
+	if capacity < 1 {
+		panic("buffer: capacity must be >= 1")
+	}
+	return &Ring{
+		items:    make([][]collector.Metric, capacity),
+		capacity: capacity,
+	}
+}
+
+// Push adds a batch to the ring. If the buffer is full, the oldest batch
+// is silently evicted to make room.
+func (r *Ring) Push(batch []collector.Metric) {
+	if len(batch) == 0 {
+		return
+	}
+	// Copy the slice so the caller can reuse its underlying array safely.
+	cp := make([]collector.Metric, len(batch))
+	copy(cp, batch)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.count == r.capacity {
+		// Evict oldest: advance head.
+		r.head = (r.head + 1) % r.capacity
+		r.count--
+	}
+
+	r.items[r.tail] = cp
+	r.tail = (r.tail + 1) % r.capacity
+	r.count++
+}
+
+// PopAll removes and returns all buffered batches in FIFO order.
+// Returns nil if the buffer is empty.
+func (r *Ring) PopAll() [][]collector.Metric {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.count == 0 {
+		return nil
+	}
+
+	out := make([][]collector.Metric, r.count)
+	for i := range out {
+		out[i] = r.items[(r.head+i)%r.capacity]
+	}
+
+	// Reset.
+	r.head = 0
+	r.tail = 0
+	r.count = 0
+
+	return out
+}
+
+// Len returns the number of batches currently buffered.
+func (r *Ring) Len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.count
+}

--- a/agent/internal/buffer/ring_test.go
+++ b/agent/internal/buffer/ring_test.go
@@ -1,0 +1,120 @@
+package buffer_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/yuriPeixoto/maestro/agent/internal/buffer"
+	"github.com/yuriPeixoto/maestro/agent/internal/collector"
+)
+
+func metric(name string) collector.Metric {
+	return collector.Metric{Name: name, Value: 1.0, Timestamp: time.Now()}
+}
+
+func batch(names ...string) []collector.Metric {
+	out := make([]collector.Metric, len(names))
+	for i, n := range names {
+		out[i] = metric(n)
+	}
+	return out
+}
+
+func TestRing_EmptyPopAllReturnsNil(t *testing.T) {
+	r := buffer.New(10)
+	if got := r.PopAll(); got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+}
+
+func TestRing_PushAndPopAllFIFO(t *testing.T) {
+	r := buffer.New(10)
+	r.Push(batch("a", "b"))
+	r.Push(batch("c"))
+	r.Push(batch("d", "e", "f"))
+
+	batches := r.PopAll()
+	if len(batches) != 3 {
+		t.Fatalf("expected 3 batches, got %d", len(batches))
+	}
+	if batches[0][0].Name != "a" {
+		t.Errorf("expected first batch first metric 'a', got %q", batches[0][0].Name)
+	}
+	if batches[1][0].Name != "c" {
+		t.Errorf("expected second batch first metric 'c', got %q", batches[1][0].Name)
+	}
+	if batches[2][0].Name != "d" {
+		t.Errorf("expected third batch first metric 'd', got %q", batches[2][0].Name)
+	}
+}
+
+func TestRing_PopAllClearsBuffer(t *testing.T) {
+	r := buffer.New(10)
+	r.Push(batch("x"))
+	r.PopAll()
+
+	if r.Len() != 0 {
+		t.Fatalf("expected 0 after PopAll, got %d", r.Len())
+	}
+	if got := r.PopAll(); got != nil {
+		t.Fatalf("expected nil on second PopAll, got %v", got)
+	}
+}
+
+func TestRing_EvictsOldestWhenFull(t *testing.T) {
+	cap := 3
+	r := buffer.New(cap)
+
+	// Fill to capacity.
+	r.Push(batch("first"))
+	r.Push(batch("second"))
+	r.Push(batch("third"))
+
+	// One more — "first" should be evicted.
+	r.Push(batch("fourth"))
+
+	if r.Len() != cap {
+		t.Fatalf("expected len=%d after overflow, got %d", cap, r.Len())
+	}
+
+	batches := r.PopAll()
+	if batches[0][0].Name != "second" {
+		t.Errorf("expected 'second' after eviction of 'first', got %q", batches[0][0].Name)
+	}
+	if batches[cap-1][0].Name != "fourth" {
+		t.Errorf("expected last batch to be 'fourth', got %q", batches[cap-1][0].Name)
+	}
+}
+
+func TestRing_PushEmptyBatchIsNoop(t *testing.T) {
+	r := buffer.New(5)
+	r.Push(nil)
+	r.Push([]collector.Metric{})
+
+	if r.Len() != 0 {
+		t.Fatalf("expected 0 after pushing empty batches, got %d", r.Len())
+	}
+}
+
+func TestRing_PanicOnZeroCapacity(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for capacity 0")
+		}
+	}()
+	buffer.New(0)
+}
+
+func TestRing_IsolatesPushedSlice(t *testing.T) {
+	r := buffer.New(5)
+	original := batch("original")
+	r.Push(original)
+
+	// Mutate the original slice — the ring must not reflect this change.
+	original[0].Name = "mutated"
+
+	batches := r.PopAll()
+	if batches[0][0].Name != "original" {
+		t.Errorf("ring buffer must copy the batch on Push; got %q", batches[0][0].Name)
+	}
+}

--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -11,8 +11,18 @@ type Config struct {
 	ServerID  string
 	Redis     RedisConfig
 	Intervals IntervalConfig
+	Buffer    BufferConfig
 	// Debug prints metrics to stdout instead of Redis. Set MAESTRO_DEBUG=true.
 	Debug bool
+}
+
+// BufferConfig controls the in-memory ring buffer used when Redis is unavailable.
+type BufferConfig struct {
+	// Capacity is the maximum number of metric batches the ring buffer holds.
+	// When full, the oldest batch is evicted. Default: 1000.
+	Capacity int
+	// RetryInterval is how often the publisher attempts to flush the buffer to Redis.
+	RetryInterval time.Duration
 }
 
 type RedisConfig struct {
@@ -58,6 +68,10 @@ func Default() Config {
 			Addr:     redisAddr,
 			Password: os.Getenv("MAESTRO_REDIS_PASSWORD"),
 			Stream:   stream,
+		},
+		Buffer: BufferConfig{
+			Capacity:      1000,
+			RetryInterval: 30 * time.Second,
 		},
 		Intervals: IntervalConfig{
 			CPU:          5 * time.Second,

--- a/agent/internal/publisher/publisher.go
+++ b/agent/internal/publisher/publisher.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/redis/go-redis/v9"
 
+	"github.com/yuriPeixoto/maestro/agent/internal/buffer"
 	"github.com/yuriPeixoto/maestro/agent/internal/collector"
 )
 
@@ -23,18 +24,29 @@ type Config struct {
 	RedisPassword string
 	Stream        string
 	Debug         bool // if true, print to stdout instead of Redis
+	BufferCap     int
+	RetryInterval time.Duration
 }
 
 // Publisher drains the metric channel, batches metrics, and sends them
-// to Redis Streams. In Debug mode it prints to stdout instead.
+// to Redis Streams. Failed writes are retained in a local ring buffer and
+// retried on a separate ticker. In Debug mode it prints to stdout instead.
 type Publisher struct {
 	cfg    Config
 	client *redis.Client
+	ring   *buffer.Ring
 }
 
 // New creates a Publisher. In non-debug mode it establishes a Redis connection.
 func New(cfg Config) (*Publisher, error) {
-	p := &Publisher{cfg: cfg}
+	cap := cfg.BufferCap
+	if cap < 1 {
+		cap = 1000
+	}
+	p := &Publisher{
+		cfg:  cfg,
+		ring: buffer.New(cap),
+	}
 
 	if !cfg.Debug {
 		p.client = redis.NewClient(&redis.Options{
@@ -56,11 +68,20 @@ func New(cfg Config) (*Publisher, error) {
 }
 
 // Run reads from in, accumulates a batch, and flushes when either
-// batchSize is reached or flushTimeout elapses. Blocks until ctx is cancelled.
+// batchSize is reached or flushTimeout elapses. A separate retry ticker
+// drains the ring buffer back to Redis when it becomes available.
+// Blocks until ctx is cancelled.
 func (p *Publisher) Run(ctx context.Context, in <-chan collector.Metric) {
 	batch := make([]collector.Metric, 0, batchSize)
-	timer := time.NewTimer(flushTimeout)
-	defer timer.Stop()
+	flushTicker := time.NewTicker(flushTimeout)
+	defer flushTicker.Stop()
+
+	retryInterval := p.cfg.RetryInterval
+	if retryInterval <= 0 {
+		retryInterval = 30 * time.Second
+	}
+	retryTicker := time.NewTicker(retryInterval)
+	defer retryTicker.Stop()
 
 	flush := func() {
 		if len(batch) == 0 {
@@ -84,24 +105,23 @@ func (p *Publisher) Run(ctx context.Context, in <-chan collector.Metric) {
 			batch = append(batch, m)
 			if len(batch) >= batchSize {
 				flush()
-				if !timer.Stop() {
-					select {
-					case <-timer.C:
-					default:
-					}
-				}
-				timer.Reset(flushTimeout)
+				flushTicker.Reset(flushTimeout)
 			}
 
-		case <-timer.C:
+		case <-flushTicker.C:
 			flush()
-			timer.Reset(flushTimeout)
+
+		case <-retryTicker.C:
+			p.drainBuffer(ctx)
 		}
 	}
 }
 
 // sendBatch serialises each Metric and sends it to Redis Streams via XADD.
+// On failure the entire batch is pushed to the ring buffer for later retry.
 func (p *Publisher) sendBatch(ctx context.Context, batch []collector.Metric) {
+	var failed []collector.Metric
+
 	for _, m := range batch {
 		payload, err := json.Marshal(m)
 		if err != nil {
@@ -115,10 +135,57 @@ func (p *Publisher) sendBatch(ctx context.Context, batch []collector.Metric) {
 			},
 		}).Err()
 		if err != nil {
-			log.Printf("warn [publisher]: redis XADD failed: %v", err)
+			log.Printf("warn [publisher]: redis XADD failed: %v — buffering metric", err)
+			failed = append(failed, m)
 		}
 	}
-	log.Printf("debug [publisher]: flushed %d metrics to stream %s", len(batch), p.cfg.Stream)
+
+	if len(failed) > 0 {
+		p.ring.Push(failed)
+		log.Printf("warn [publisher]: buffered %d failed metrics (buffer size: %d)", len(failed), p.ring.Len())
+	} else {
+		log.Printf("debug [publisher]: flushed %d metrics to stream %s", len(batch), p.cfg.Stream)
+	}
+}
+
+// drainBuffer attempts to flush all buffered batches back to Redis.
+// Batches that fail again are re-queued into the ring buffer.
+func (p *Publisher) drainBuffer(ctx context.Context) {
+	batches := p.ring.PopAll()
+	if len(batches) == 0 {
+		return
+	}
+
+	log.Printf("info [publisher]: retrying %d buffered batch(es)...", len(batches))
+	requeued := 0
+
+	for _, batch := range batches {
+		var failed []collector.Metric
+		for _, m := range batch {
+			payload, err := json.Marshal(m)
+			if err != nil {
+				continue
+			}
+			err = p.client.XAdd(ctx, &redis.XAddArgs{
+				Stream: p.cfg.Stream,
+				Values: map[string]any{"data": string(payload)},
+			}).Err()
+			if err != nil {
+				failed = append(failed, m)
+			}
+		}
+		if len(failed) > 0 {
+			p.ring.Push(failed)
+			requeued++
+		}
+	}
+
+	flushed := len(batches) - requeued
+	if flushed > 0 {
+		log.Printf("info [publisher]: retry flushed %d batch(es), %d re-queued", flushed, requeued)
+	} else {
+		log.Printf("warn [publisher]: retry failed — all %d batch(es) re-queued", requeued)
+	}
 }
 
 // printBatch prints metrics as formatted JSON lines for debug inspection.


### PR DESCRIPTION
## Summary

- Adds `internal/buffer.Ring`: thread-safe fixed-capacity circular buffer
  - FIFO order, O(1) push/pop, evicts oldest batch when full (no blocking, no crash)
  - Copies slices on Push to isolate caller's backing array
- Publisher integrates the buffer: Redis XADD failures → metrics stored in ring, not dropped
- Retry ticker (default 30 s, configurable) drains buffered batches when Redis recovers
- `config.BufferConfig` added: `Capacity` (default 1000) + `RetryInterval` (default 30 s)

## Test plan

- [x] 7 unit tests in `internal/buffer/ring_test.go` — all pass
- [x] `go build ./...` — no errors
- [x] FIFO order verified
- [x] Eviction of oldest batch when capacity exceeded
- [x] Empty Push is a no-op
- [x] Slice isolation on Push
- [x] Panic on capacity 0