### PR TITLE
feat(agent): implement heartbeat emitter (closes #3)

### DIFF
--- a/agent/cmd/agent/main.go
+++ b/agent/cmd/agent/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/yuriPeixoto/maestro/agent/internal/collector"
 	"github.com/yuriPeixoto/maestro/agent/internal/config"
+	"github.com/yuriPeixoto/maestro/agent/internal/heartbeat"
 	"github.com/yuriPeixoto/maestro/agent/internal/publisher"
 )
 
@@ -36,6 +37,18 @@ func main() {
 	// Context cancelled on SIGINT / SIGTERM for graceful shutdown.
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
+
+	// Heartbeat emitter — runs independently, failures never affect metric collection.
+	if err := heartbeat.Start(ctx, heartbeat.Config{
+		ServerID:      cfg.ServerID,
+		Stream:        cfg.Heartbeat.Stream,
+		Interval:      cfg.Heartbeat.Interval,
+		RedisAddr:     cfg.Redis.Addr,
+		RedisPassword: cfg.Redis.Password,
+		Debug:         cfg.Debug,
+	}); err != nil {
+		log.Printf("warn: heartbeat emitter failed to start: %v — continuing without heartbeat", err)
+	}
 
 	// Start all metric collectors (each runs as an independent goroutine).
 	collector.Start(ctx, cfg.ServerID, collector.IntervalConfig{

--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	Redis     RedisConfig
 	Intervals IntervalConfig
 	Buffer    BufferConfig
+	Heartbeat HeartbeatConfig
 	// Debug prints metrics to stdout instead of Redis. Set MAESTRO_DEBUG=true.
 	Debug bool
 }
@@ -29,6 +30,16 @@ type RedisConfig struct {
 	Addr     string
 	Password string
 	Stream   string
+}
+
+// HeartbeatConfig controls the heartbeat emitter.
+type HeartbeatConfig struct {
+	// Interval is how often a heartbeat is emitted to Redis.
+	// Configurable via MAESTRO_HEARTBEAT_INTERVAL (e.g. "30s"). Default: 30s.
+	Interval time.Duration
+	// Stream is the Redis Streams key used exclusively for heartbeats.
+	// Configurable via MAESTRO_HEARTBEAT_STREAM. Default: "maestro:heartbeat".
+	Stream string
 }
 
 // IntervalConfig defines per-metric sampling rates.
@@ -61,6 +72,18 @@ func Default() Config {
 		stream = "maestro:metrics"
 	}
 
+	heartbeatStream := os.Getenv("MAESTRO_HEARTBEAT_STREAM")
+	if heartbeatStream == "" {
+		heartbeatStream = "maestro:heartbeat"
+	}
+
+	heartbeatInterval := 30 * time.Second
+	if raw := os.Getenv("MAESTRO_HEARTBEAT_INTERVAL"); raw != "" {
+		if d, err := time.ParseDuration(raw); err == nil {
+			heartbeatInterval = d
+		}
+	}
+
 	return Config{
 		ServerID: serverID,
 		Debug:    os.Getenv("MAESTRO_DEBUG") == "true",
@@ -68,6 +91,10 @@ func Default() Config {
 			Addr:     redisAddr,
 			Password: os.Getenv("MAESTRO_REDIS_PASSWORD"),
 			Stream:   stream,
+		},
+		Heartbeat: HeartbeatConfig{
+			Interval: heartbeatInterval,
+			Stream:   heartbeatStream,
 		},
 		Buffer: BufferConfig{
 			Capacity:      1000,

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -1,0 +1,110 @@
+package heartbeat
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Version is the current agent version, injected at build time via -ldflags.
+// Falls back to "dev" when not set.
+var Version = "dev"
+
+// Payload is the heartbeat message emitted to Redis Streams.
+type Payload struct {
+	ServerID     string    `json:"server_id"`
+	Timestamp    time.Time `json:"timestamp"`
+	AgentVersion string    `json:"agent_version"`
+}
+
+// Config holds all parameters needed by the emitter.
+type Config struct {
+	ServerID      string
+	Stream        string
+	Interval      time.Duration
+	RedisAddr     string
+	RedisPassword string
+	Debug         bool
+}
+
+// Start launches the heartbeat emitter as a goroutine.
+// It connects to Redis independently from the metric publisher, emits a
+// heartbeat on every tick, and logs failures without affecting metric collection.
+func Start(ctx context.Context, cfg Config) error {
+	if cfg.Interval <= 0 {
+		cfg.Interval = 30 * time.Second
+	}
+
+	var client *redis.Client
+	if !cfg.Debug {
+		client = redis.NewClient(&redis.Options{
+			Addr:     cfg.RedisAddr,
+			Password: cfg.RedisPassword,
+		})
+		pingCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		defer cancel()
+		if err := client.Ping(pingCtx).Err(); err != nil {
+			return fmt.Errorf("heartbeat: redis connection failed (%s): %w", cfg.RedisAddr, err)
+		}
+		log.Printf("info [heartbeat]: connected to Redis at %s, stream=%s, interval=%s",
+			cfg.RedisAddr, cfg.Stream, cfg.Interval)
+	} else {
+		log.Printf("info [heartbeat]: DEBUG mode — heartbeats will be printed to stdout")
+	}
+
+	go func() {
+		if client != nil {
+			defer client.Close()
+		}
+
+		ticker := time.NewTicker(cfg.Interval)
+		defer ticker.Stop()
+
+		// Emit immediately on startup so the server is visible right away.
+		emit(ctx, cfg, client)
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				emit(ctx, cfg, client)
+			}
+		}
+	}()
+
+	return nil
+}
+
+func emit(ctx context.Context, cfg Config, client *redis.Client) {
+	p := Payload{
+		ServerID:     cfg.ServerID,
+		Timestamp:    time.Now().UTC(),
+		AgentVersion: Version,
+	}
+
+	payload, err := json.Marshal(p)
+	if err != nil {
+		log.Printf("warn [heartbeat]: marshal failed: %v", err)
+		return
+	}
+
+	if cfg.Debug {
+		log.Printf("debug [heartbeat]: %s", string(payload))
+		return
+	}
+
+	err = client.XAdd(ctx, &redis.XAddArgs{
+		Stream: cfg.Stream,
+		Values: map[string]any{"data": string(payload)},
+	}).Err()
+	if err != nil {
+		log.Printf("warn [heartbeat]: XADD to stream %q failed: %v — skipping", cfg.Stream, err)
+	} else {
+		log.Printf("debug [heartbeat]: emitted to stream %s", cfg.Stream)
+	}
+}

--- a/agent/internal/heartbeat/heartbeat_test.go
+++ b/agent/internal/heartbeat/heartbeat_test.go
@@ -1,0 +1,63 @@
+package heartbeat
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestStartDebugMode verifies that Start returns no error in debug mode
+// and the goroutine runs without panicking.
+func TestStartDebugMode(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	err := Start(ctx, Config{
+		ServerID: "test-server",
+		Stream:   "maestro:heartbeat",
+		Interval: 50 * time.Millisecond,
+		Debug:    true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Let at least two ticks fire.
+	time.Sleep(120 * time.Millisecond)
+	cancel()
+
+	// Allow goroutine to exit cleanly.
+	time.Sleep(10 * time.Millisecond)
+}
+
+// TestPayloadFields verifies the payload is populated correctly.
+func TestPayloadFields(t *testing.T) {
+	Version = "1.2.3"
+	before := time.Now().UTC()
+
+	p := Payload{
+		ServerID:     "srv-01",
+		Timestamp:    time.Now().UTC(),
+		AgentVersion: Version,
+	}
+
+	if p.ServerID != "srv-01" {
+		t.Errorf("unexpected server_id: %q", p.ServerID)
+	}
+	if p.AgentVersion != "1.2.3" {
+		t.Errorf("unexpected agent_version: %q", p.AgentVersion)
+	}
+	if p.Timestamp.Before(before) {
+		t.Errorf("timestamp %v is before test start %v", p.Timestamp, before)
+	}
+}
+
+// TestDefaultInterval ensures a zero interval falls back to 30 seconds.
+func TestDefaultInterval(t *testing.T) {
+	cfg := Config{Interval: 0}
+	if cfg.Interval <= 0 {
+		cfg.Interval = 30 * time.Second
+	}
+	if cfg.Interval != 30*time.Second {
+		t.Errorf("expected 30s default, got %v", cfg.Interval)
+	}
+}


### PR DESCRIPTION
## Summary

- Implemented a heartbeat emitter (`internal/heartbeat`) that runs as an independent goroutine, completely decoupled from metric collection
- Heartbeat is emitted immediately on startup and then every tick to a **dedicated Redis Stream** (`maestro:heartbeat` by default), separate from the metrics stream
- Payload includes `server_id`, `timestamp` (UTC), and `agent_version` (injectable via `-ldflags` at build time, defaults to `"dev"`)
- Failures are logged as `warn` and never propagate — metric collection is unaffected
- Interval (`MAESTRO_HEARTBEAT_INTERVAL`) and stream name (`MAESTRO_HEARTBEAT_STREAM`) are fully configurable via env vars
- Also includes the local ring buffer implementation from #2 (branch was built on top of that work)

## Components Changed

- [x] Agent (Go)
- [ ] API (Python)
- [ ] Frontend (React)
- [ ] Infra / Config

## Test Plan

- [x] Go: `go test ./...` passing (3 new tests in `internal/heartbeat`)
- [ ] Python: testes passando
- [ ] Frontend: `npm run type-check` passando
- [x] Testado manualmente (debug mode logs heartbeat JSON every tick)

## Notes

The heartbeat emitter creates its own Redis connection independently from the publisher. This keeps packages decoupled and allows the heartbeat to survive publisher failures. The `Version` variable is exported so it can be set at build time:

```bash
go build -ldflags "-X github.com/yuriPeixoto/maestro/agent/internal/heartbeat.Version=1.0.0" ./cmd/agent
```

Closes #3