### PR TITLE
feat(api): Redis Streams consumer → ClickHouse batch writer (closes #6)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,64 @@
+.PHONY: agent-build agent-debug agent-test api-dev api-install migrate migrate-dry
+
+# ── Agent ────────────────────────────────────────────────────────────────────
+
+agent-build:
+	$(MAKE) -C agent build
+
+agent-debug:
+	$(MAKE) -C agent debug
+
+agent-test:
+	$(MAKE) -C agent test
+
+# ── API ───────────────────────────────────────────────────────────────────────
+
+# Install Python dependencies (run once, or after requirements.txt changes)
+api-install:
+	pip install -r api/requirements.txt
+
+# Run the FastAPI dev server with auto-reload
+api-dev:
+	uvicorn app.main:app --reload --app-dir api --host 0.0.0.0 --port 8000
+
+# ── ClickHouse Migrations ─────────────────────────────────────────────────────
+#
+# Required env vars (or edit defaults below):
+#   CLICKHOUSE_HOST     default: localhost
+#   CLICKHOUSE_PORT     default: 8123
+#   CLICKHOUSE_USER     default: default
+#   CLICKHOUSE_PASSWORD default: (empty)
+#
+# Usage:
+#   make migrate                                            # apply all migrations
+#   make migrate FILE=migrations/001_create_metrics.sql    # apply one file
+
+CLICKHOUSE_HOST     ?= localhost
+CLICKHOUSE_PORT     ?= 8123
+CLICKHOUSE_USER     ?= default
+CLICKHOUSE_PASSWORD ?=
+
+CLICKHOUSE_CMD = clickhouse-client \
+	--host $(CLICKHOUSE_HOST) \
+	--port $(CLICKHOUSE_PORT) \
+	--user $(CLICKHOUSE_USER) \
+	$(if $(CLICKHOUSE_PASSWORD),--password $(CLICKHOUSE_PASSWORD),) \
+	--multiquery
+
+migrate:
+ifdef FILE
+	@echo "Applying $(FILE)..."
+	$(CLICKHOUSE_CMD) < $(FILE)
+	@echo "Done."
+else
+	@echo "Applying all migrations in order..."
+	@for f in $(sort $(wildcard migrations/*.sql)); do \
+		echo "  -> $$f"; \
+		$(CLICKHOUSE_CMD) < $$f; \
+	done
+	@echo "All migrations applied."
+endif
+
+migrate-dry:
+	@echo "Migrations to apply:"
+	@for f in $(sort $(wildcard migrations/*.sql)); do echo "  $$f"; done

--- a/api/app/clickhouse.py
+++ b/api/app/clickhouse.py
@@ -1,0 +1,81 @@
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+
+import clickhouse_connect
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Column order must match the CREATE TABLE in migrations/001_create_metrics.sql.
+_COLUMNS = ["server_id", "metric_name", "value", "timestamp", "tags"]
+
+
+@dataclass
+class MetricRow:
+    server_id: str
+    metric_name: str
+    value: float
+    timestamp: datetime
+    tags: dict
+
+
+class ClickHouseWriter:
+    """Async wrapper around clickhouse-connect for batch metric inserts."""
+
+    def __init__(self) -> None:
+        self._client = clickhouse_connect.get_async_client(
+            host=settings.clickhouse_host,
+            port=settings.clickhouse_port,
+            username=settings.clickhouse_user,
+            password=settings.clickhouse_password,
+            database=settings.clickhouse_database,
+        )
+
+    async def insert_batch(self, rows: list[MetricRow]) -> None:
+        """Insert a batch of metric rows into ClickHouse with exponential backoff retry.
+
+        If all retry attempts fail, the batch is logged and dropped — the consumer
+        will still XACK those messages so the stream does not grow unboundedly.
+        """
+        if not rows:
+            return
+
+        data = [
+            [r.server_id, r.metric_name, r.value, r.timestamp, r.tags or {}]
+            for r in rows
+        ]
+
+        delay = settings.consumer_retry_base_delay
+        for attempt in range(1, settings.consumer_retry_max + 1):
+            try:
+                await self._client.insert(
+                    "metrics",
+                    data=data,
+                    column_names=_COLUMNS,
+                )
+                logger.debug("clickhouse: inserted %d rows", len(rows))
+                return
+            except Exception as exc:
+                if attempt == settings.consumer_retry_max:
+                    logger.error(
+                        "clickhouse: insert failed after %d attempts, dropping %d rows: %s",
+                        attempt,
+                        len(rows),
+                        exc,
+                    )
+                    return
+                logger.warning(
+                    "clickhouse: insert attempt %d/%d failed: %s — retrying in %.1fs",
+                    attempt,
+                    settings.consumer_retry_max,
+                    exc,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+                delay *= 2
+
+    async def close(self) -> None:
+        await self._client.close()

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -1,0 +1,27 @@
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    # Redis
+    redis_url: str = "redis://localhost:6379"
+    redis_stream: str = "maestro:metrics"
+    redis_consumer_group: str = "maestro-api"
+    redis_consumer_name: str = "worker-1"
+
+    # ClickHouse
+    clickhouse_host: str = "localhost"
+    clickhouse_port: int = 8123
+    clickhouse_user: str = "default"
+    clickhouse_password: str = ""
+    clickhouse_database: str = "maestro"
+
+    # Consumer tuning
+    consumer_batch_size: int = 500       # max rows per ClickHouse insert
+    consumer_flush_interval_ms: int = 5000  # XREADGROUP block timeout (ms)
+    consumer_retry_max: int = 3          # ClickHouse insert retry attempts
+    consumer_retry_base_delay: float = 1.0  # seconds (doubles on each retry)
+
+    model_config = {"env_prefix": "MAESTRO_"}
+
+
+settings = Settings()

--- a/api/app/consumer.py
+++ b/api/app/consumer.py
@@ -1,0 +1,143 @@
+import asyncio
+import json
+import logging
+from datetime import datetime, timezone
+
+import redis.asyncio as aioredis
+
+from app.clickhouse import ClickHouseWriter, MetricRow
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_metric(raw: str) -> MetricRow | None:
+    """Parse a JSON metric payload published by the Go agent.
+
+    Expected shape:
+        {
+            "server_id":   "hostname",
+            "metric_name": "cpu_usage_percent",
+            "value":       42.5,
+            "timestamp":   "2026-03-09T12:00:00Z",
+            "tags":        {"device": "sda"}   // optional
+        }
+    """
+    try:
+        data = json.loads(raw)
+        ts_raw = data["timestamp"]
+        # Accept both RFC3339 with Z suffix and +00:00.
+        ts_raw = ts_raw.replace("Z", "+00:00")
+        timestamp = datetime.fromisoformat(ts_raw).astimezone(timezone.utc).replace(tzinfo=None)
+        return MetricRow(
+            server_id=data["server_id"],
+            metric_name=data["metric_name"],
+            value=float(data["value"]),
+            timestamp=timestamp,
+            tags=data.get("tags") or {},
+        )
+    except Exception as exc:
+        logger.warning("consumer: failed to parse metric payload: %s — raw: %.200s", exc, raw)
+        return None
+
+
+async def _ensure_consumer_group(redis: aioredis.Redis) -> None:
+    """Create the consumer group if it does not exist.
+
+    MKSTREAM creates the stream if it does not yet exist (e.g. agent hasn't
+    started yet). Starting at '$' means we only consume new messages — we do
+    not replay historical data on first boot.
+    """
+    try:
+        await redis.xgroup_create(
+            name=settings.redis_stream,
+            groupname=settings.redis_consumer_group,
+            id="$",
+            mkstream=True,
+        )
+        logger.info(
+            "consumer: created consumer group '%s' on stream '%s'",
+            settings.redis_consumer_group,
+            settings.redis_stream,
+        )
+    except aioredis.ResponseError as exc:
+        if "BUSYGROUP" in str(exc):
+            # Group already exists — normal on restart.
+            logger.debug("consumer: consumer group already exists, continuing")
+        else:
+            raise
+
+
+async def run_consumer(writer: ClickHouseWriter) -> None:
+    """Main consumer loop. Reads from Redis Streams, batches rows, writes to ClickHouse.
+
+    Runs indefinitely — expected to be launched as an asyncio background task
+    and cancelled on application shutdown.
+    """
+    redis = aioredis.from_url(settings.redis_url, decode_responses=True)
+
+    try:
+        await _ensure_consumer_group(redis)
+        logger.info(
+            "consumer: listening on stream '%s' (group='%s', consumer='%s', batch=%d)",
+            settings.redis_stream,
+            settings.redis_consumer_group,
+            settings.redis_consumer_name,
+            settings.consumer_batch_size,
+        )
+
+        while True:
+            try:
+                # Block up to flush_interval_ms waiting for new messages.
+                # '>' delivers only messages not yet assigned to any consumer in the group.
+                results = await redis.xreadgroup(
+                    groupname=settings.redis_consumer_group,
+                    consumername=settings.redis_consumer_name,
+                    streams={settings.redis_stream: ">"},
+                    count=settings.consumer_batch_size,
+                    block=settings.consumer_flush_interval_ms,
+                )
+            except aioredis.RedisError as exc:
+                logger.error("consumer: redis read error: %s — retrying in 5s", exc)
+                await asyncio.sleep(5)
+                continue
+
+            if not results:
+                # Timeout with no messages — normal during low traffic.
+                continue
+
+            # results shape: [(stream_name, [(msg_id, {field: value}), ...])]
+            _stream_name, messages = results[0]
+
+            rows: list[MetricRow] = []
+            msg_ids: list[str] = []
+
+            for msg_id, fields in messages:
+                raw = fields.get("data", "")
+                row = _parse_metric(raw)
+                if row is not None:
+                    rows.append(row)
+                msg_ids.append(msg_id)
+
+            # Write to ClickHouse — insert_batch handles retries and drops on failure.
+            if rows:
+                await writer.insert_batch(rows)
+
+            # Acknowledge all messages (including those that failed to parse).
+            # This prevents them from being redelivered and blocking the stream.
+            if msg_ids:
+                await redis.xack(
+                    settings.redis_stream,
+                    settings.redis_consumer_group,
+                    *msg_ids,
+                )
+                logger.debug(
+                    "consumer: acked %d message(s), inserted %d row(s)",
+                    len(msg_ids),
+                    len(rows),
+                )
+
+    except asyncio.CancelledError:
+        logger.info("consumer: shutting down")
+    finally:
+        await redis.aclose()

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,10 +1,44 @@
+import asyncio
+import logging
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 
-app = FastAPI(title="Maestro API")
+from app.clickhouse import ClickHouseWriter
+from app.consumer import run_consumer
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Start the Redis Streams consumer on startup; cancel it on shutdown."""
+    writer = ClickHouseWriter()
+    task = asyncio.create_task(run_consumer(writer), name="redis-consumer")
+    logger.info("app: Redis Streams consumer started")
+
+    yield  # application runs here
+
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    await writer.close()
+    logger.info("app: consumer stopped, ClickHouse connection closed")
+
+
+app = FastAPI(title="Maestro API", lifespan=lifespan)
+
 
 @app.get("/")
 async def root():
     return {"message": "Maestro API is running"}
+
 
 @app.get("/health")
 async def health():

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,3 +3,5 @@ uvicorn[standard]
 pydantic
 pydantic-settings
 httpx
+redis[hiredis]
+clickhouse-connect


### PR DESCRIPTION
## Summary

- **`app/config.py`**: `Settings` via `pydantic-settings` with `MAESTRO_` env prefix — Redis URL, ClickHouse host/port/user/pass/db, consumer batch size, flush interval, retry config
- **`app/clickhouse.py`**: `ClickHouseWriter` using `clickhouse-connect` async client; `insert_batch()` with exponential backoff retry (default: 3 attempts, 1s → 2s → 4s); drops batch after all retries with error log
- **`app/consumer.py`**: `run_consumer()` coroutine — `XREADGROUP` with `MKSTREAM` on group creation; parses each `data` field as JSON into `MetricRow`; `XACK` after insert; parse errors skip the row without blocking the stream; Redis errors retry after 5s
- **`app/main.py`**: `lifespan` context starts the consumer as an `asyncio.create_task`; clean shutdown cancels task and closes ClickHouse connection
- **`requirements.txt`**: added `redis[hiredis]`, `clickhouse-connect`
- **`Makefile`** (root): `make api-dev` runs uvicorn with auto-reload; `make api-install` installs deps

## Behaviour

| Scenario | Behaviour |
|---|---|
| Redis unavailable | Logs error, retries every 5s |
| ClickHouse insert fails | Exponential backoff × 3, then drops + logs |
| Malformed JSON in stream | Row skipped, message still acked |
| Agent not started yet | `MKSTREAM` creates the stream; consumer waits on `BLOCK` timeout |
| Clean shutdown (SIGINT) | Task cancelled, connection closed gracefully |

## Test plan

- [ ] `pip install -r api/requirements.txt` — no errors
- [ ] `make api-dev` starts uvicorn on port 8000
- [ ] `GET /health` returns `{"status": "healthy"}`
- [ ] With agent running in debug mode + Redis up: consumer logs `inserted N rows`
- [ ] Stopping ClickHouse mid-run: retry warnings appear, then drop log after 3 attempts

🤖 Generated with [Claude Code](https://claude.com/claude-code)