### PR TITLE
feat(api): heartbeat tracking and server online/offline detection (closes #7)

### DIFF
--- a/api/app/clickhouse.py
+++ b/api/app/clickhouse.py
@@ -1,0 +1,66 @@
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+
+import clickhouse_connect
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+_COLUMNS = ["server_id", "metric_name", "value", "timestamp", "tags"]
+
+
+@dataclass
+class MetricRow:
+    server_id: str
+    metric_name: str
+    value: float
+    timestamp: datetime
+    tags: dict
+
+
+class ClickHouseWriter:
+    """Async wrapper around clickhouse-connect for batch metric inserts."""
+
+    def __init__(self) -> None:
+        self._client = clickhouse_connect.get_async_client(
+            host=settings.clickhouse_host,
+            port=settings.clickhouse_port,
+            username=settings.clickhouse_user,
+            password=settings.clickhouse_password,
+            database=settings.clickhouse_database,
+        )
+
+    async def insert_batch(self, rows: list[MetricRow]) -> None:
+        if not rows:
+            return
+
+        data = [
+            [r.server_id, r.metric_name, r.value, r.timestamp, r.tags or {}]
+            for r in rows
+        ]
+
+        delay = settings.consumer_retry_base_delay
+        for attempt in range(1, settings.consumer_retry_max + 1):
+            try:
+                await self._client.insert("metrics", data=data, column_names=_COLUMNS)
+                logger.debug("clickhouse: inserted %d rows", len(rows))
+                return
+            except Exception as exc:
+                if attempt == settings.consumer_retry_max:
+                    logger.error(
+                        "clickhouse: insert failed after %d attempts, dropping %d rows: %s",
+                        attempt, len(rows), exc,
+                    )
+                    return
+                logger.warning(
+                    "clickhouse: attempt %d/%d failed: %s — retrying in %.1fs",
+                    attempt, settings.consumer_retry_max, exc, delay,
+                )
+                await asyncio.sleep(delay)
+                delay *= 2
+
+    async def close(self) -> None:
+        await self._client.close()

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -1,0 +1,36 @@
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    # Redis
+    redis_url: str = "redis://localhost:6379"
+    redis_stream: str = "maestro:metrics"
+    redis_consumer_group: str = "maestro-api"
+    redis_consumer_name: str = "worker-1"
+
+    # Heartbeat
+    heartbeat_stream: str = "maestro:heartbeat"
+    heartbeat_consumer_group: str = "maestro-heartbeat"
+    heartbeat_consumer_name: str = "heartbeat-worker-1"
+    # Redis hash key where last_seen state is stored: field=server_id, value=JSON
+    heartbeat_state_key: str = "maestro:server_heartbeats"
+    # Seconds without a heartbeat before a server is considered offline
+    offline_threshold_seconds: int = 90
+
+    # ClickHouse
+    clickhouse_host: str = "localhost"
+    clickhouse_port: int = 8123
+    clickhouse_user: str = "default"
+    clickhouse_password: str = ""
+    clickhouse_database: str = "maestro"
+
+    # Consumer tuning
+    consumer_batch_size: int = 500
+    consumer_flush_interval_ms: int = 5000
+    consumer_retry_max: int = 3
+    consumer_retry_base_delay: float = 1.0
+
+    model_config = {"env_prefix": "MAESTRO_"}
+
+
+settings = Settings()

--- a/api/app/consumer.py
+++ b/api/app/consumer.py
@@ -1,0 +1,87 @@
+import asyncio
+import json
+import logging
+from datetime import datetime, timezone
+
+import redis.asyncio as aioredis
+
+from app.clickhouse import ClickHouseWriter, MetricRow
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_metric(raw: str) -> MetricRow | None:
+    try:
+        data = json.loads(raw)
+        ts_raw = data["timestamp"].replace("Z", "+00:00")
+        timestamp = datetime.fromisoformat(ts_raw).astimezone(timezone.utc).replace(tzinfo=None)
+        return MetricRow(
+            server_id=data["server_id"],
+            metric_name=data["metric_name"],
+            value=float(data["value"]),
+            timestamp=timestamp,
+            tags=data.get("tags") or {},
+        )
+    except Exception as exc:
+        logger.warning("consumer: failed to parse metric: %s — raw: %.200s", exc, raw)
+        return None
+
+
+async def _ensure_group(redis: aioredis.Redis, stream: str, group: str) -> None:
+    try:
+        await redis.xgroup_create(name=stream, groupname=group, id="$", mkstream=True)
+        logger.info("consumer: created group '%s' on stream '%s'", group, stream)
+    except aioredis.ResponseError as exc:
+        if "BUSYGROUP" not in str(exc):
+            raise
+
+
+async def run_consumer(writer: ClickHouseWriter) -> None:
+    """Reads from the metrics Redis stream and writes batches to ClickHouse."""
+    redis = aioredis.from_url(settings.redis_url, decode_responses=True)
+
+    try:
+        await _ensure_group(redis, settings.redis_stream, settings.redis_consumer_group)
+        logger.info(
+            "consumer: listening on '%s' (group='%s', batch=%d)",
+            settings.redis_stream, settings.redis_consumer_group, settings.consumer_batch_size,
+        )
+
+        while True:
+            try:
+                results = await redis.xreadgroup(
+                    groupname=settings.redis_consumer_group,
+                    consumername=settings.redis_consumer_name,
+                    streams={settings.redis_stream: ">"},
+                    count=settings.consumer_batch_size,
+                    block=settings.consumer_flush_interval_ms,
+                )
+            except aioredis.RedisError as exc:
+                logger.error("consumer: redis error: %s — retrying in 5s", exc)
+                await asyncio.sleep(5)
+                continue
+
+            if not results:
+                continue
+
+            _stream, messages = results[0]
+            rows, msg_ids = [], []
+
+            for msg_id, fields in messages:
+                row = _parse_metric(fields.get("data", ""))
+                if row is not None:
+                    rows.append(row)
+                msg_ids.append(msg_id)
+
+            if rows:
+                await writer.insert_batch(rows)
+
+            if msg_ids:
+                await redis.xack(settings.redis_stream, settings.redis_consumer_group, *msg_ids)
+                logger.debug("consumer: acked %d, inserted %d rows", len(msg_ids), len(rows))
+
+    except asyncio.CancelledError:
+        logger.info("consumer: shutting down")
+    finally:
+        await redis.aclose()

--- a/api/app/heartbeat.py
+++ b/api/app/heartbeat.py
@@ -1,0 +1,111 @@
+import asyncio
+import json
+import logging
+from datetime import datetime, timezone
+
+import redis.asyncio as aioredis
+
+from app.config import settings
+from app.consumer import _ensure_group
+
+logger = logging.getLogger(__name__)
+
+# Redis hash structure:
+#   key:   maestro:server_heartbeats
+#   field: server_id
+#   value: JSON { "last_seen": "<ISO8601 UTC>", "agent_version": "<str>" }
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_heartbeat(raw: str) -> dict | None:
+    """Parse the heartbeat payload emitted by the Go agent.
+
+    Expected shape:
+        {"server_id": "hostname", "timestamp": "2026-03-09T12:00:00Z", "agent_version": "dev"}
+    """
+    try:
+        data = json.loads(raw)
+        ts_raw = data["timestamp"].replace("Z", "+00:00")
+        last_seen = datetime.fromisoformat(ts_raw).astimezone(timezone.utc)
+        return {
+            "server_id": data["server_id"],
+            "last_seen": last_seen.isoformat(),
+            "agent_version": data.get("agent_version", "unknown"),
+        }
+    except Exception as exc:
+        logger.warning("heartbeat: failed to parse payload: %s — raw: %.200s", exc, raw)
+        return None
+
+
+async def run_heartbeat_consumer() -> None:
+    """Reads from the heartbeat Redis stream and updates server last_seen state.
+
+    State is stored in a Redis hash so reads are O(1) per server.
+    Runs as an asyncio background task alongside the metrics consumer.
+    """
+    redis = aioredis.from_url(settings.redis_url, decode_responses=True)
+
+    try:
+        await _ensure_group(
+            redis,
+            settings.heartbeat_stream,
+            settings.heartbeat_consumer_group,
+        )
+        logger.info(
+            "heartbeat: listening on '%s' (group='%s')",
+            settings.heartbeat_stream,
+            settings.heartbeat_consumer_group,
+        )
+
+        while True:
+            try:
+                results = await redis.xreadgroup(
+                    groupname=settings.heartbeat_consumer_group,
+                    consumername=settings.heartbeat_consumer_name,
+                    streams={settings.heartbeat_stream: ">"},
+                    count=100,
+                    block=10_000,  # 10s block — heartbeats arrive every 30s
+                )
+            except aioredis.RedisError as exc:
+                logger.error("heartbeat: redis error: %s — retrying in 5s", exc)
+                await asyncio.sleep(5)
+                continue
+
+            if not results:
+                continue
+
+            _stream, messages = results[0]
+            msg_ids = []
+
+            for msg_id, fields in messages:
+                parsed = _parse_heartbeat(fields.get("data", ""))
+                if parsed:
+                    await redis.hset(
+                        settings.heartbeat_state_key,
+                        parsed["server_id"],
+                        json.dumps({
+                            "last_seen": parsed["last_seen"],
+                            "agent_version": parsed["agent_version"],
+                        }),
+                    )
+                    logger.debug(
+                        "heartbeat: updated server_id='%s' last_seen=%s",
+                        parsed["server_id"],
+                        parsed["last_seen"],
+                    )
+                msg_ids.append(msg_id)
+
+            if msg_ids:
+                await redis.xack(
+                    settings.heartbeat_stream,
+                    settings.heartbeat_consumer_group,
+                    *msg_ids,
+                )
+
+    except asyncio.CancelledError:
+        logger.info("heartbeat: shutting down")
+    finally:
+        await redis.aclose()

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,10 +1,52 @@
+import asyncio
+import logging
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 
-app = FastAPI(title="Maestro API")
+from app.clickhouse import ClickHouseWriter
+from app.consumer import run_consumer
+from app.heartbeat import run_heartbeat_consumer
+from app.servers import router as servers_router
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    writer = ClickHouseWriter()
+
+    metrics_task = asyncio.create_task(run_consumer(writer), name="metrics-consumer")
+    heartbeat_task = asyncio.create_task(run_heartbeat_consumer(), name="heartbeat-consumer")
+
+    logger.info("app: metrics consumer and heartbeat consumer started")
+
+    yield
+
+    for task in (metrics_task, heartbeat_task):
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    await writer.close()
+    logger.info("app: all consumers stopped")
+
+
+app = FastAPI(title="Maestro API", lifespan=lifespan)
+
+app.include_router(servers_router)
+
 
 @app.get("/")
 async def root():
     return {"message": "Maestro API is running"}
+
 
 @app.get("/health")
 async def health():

--- a/api/app/servers.py
+++ b/api/app/servers.py
@@ -1,0 +1,81 @@
+import json
+import logging
+from datetime import datetime, timezone
+
+import redis.asyncio as aioredis
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/servers", tags=["servers"])
+
+
+# ── Response models ───────────────────────────────────────────────────────────
+
+class ServerStatus(BaseModel):
+    server_id: str
+    status: str          # "online" | "offline" | "unknown"
+    last_seen: str | None
+    agent_version: str | None
+
+
+# ── Redis dependency ──────────────────────────────────────────────────────────
+
+async def get_redis() -> aioredis.Redis:
+    redis = aioredis.from_url(settings.redis_url, decode_responses=True)
+    try:
+        yield redis
+    finally:
+        await redis.aclose()
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _resolve_status(last_seen_iso: str | None) -> str:
+    if last_seen_iso is None:
+        return "unknown"
+    try:
+        last_seen = datetime.fromisoformat(last_seen_iso)
+        if last_seen.tzinfo is None:
+            last_seen = last_seen.replace(tzinfo=timezone.utc)
+        elapsed = (datetime.now(timezone.utc) - last_seen).total_seconds()
+        return "online" if elapsed <= settings.offline_threshold_seconds else "offline"
+    except ValueError:
+        return "unknown"
+
+
+def _build_server_status(server_id: str, raw_json: str | None) -> ServerStatus:
+    if raw_json is None:
+        return ServerStatus(server_id=server_id, status="unknown", last_seen=None, agent_version=None)
+    try:
+        data = json.loads(raw_json)
+        last_seen = data.get("last_seen")
+        return ServerStatus(
+            server_id=server_id,
+            status=_resolve_status(last_seen),
+            last_seen=last_seen,
+            agent_version=data.get("agent_version"),
+        )
+    except (json.JSONDecodeError, KeyError):
+        return ServerStatus(server_id=server_id, status="unknown", last_seen=None, agent_version=None)
+
+
+# ── Routes ────────────────────────────────────────────────────────────────────
+
+@router.get("", response_model=list[ServerStatus])
+async def list_servers(redis: aioredis.Redis = Depends(get_redis)):
+    """Return all known servers with their current online/offline status."""
+    all_entries: dict[str, str] = await redis.hgetall(settings.heartbeat_state_key)
+    return [_build_server_status(server_id, raw) for server_id, raw in all_entries.items()]
+
+
+@router.get("/{server_id}/status", response_model=ServerStatus)
+async def get_server_status(server_id: str, redis: aioredis.Redis = Depends(get_redis)):
+    """Return the current status of a specific server."""
+    raw: str | None = await redis.hget(settings.heartbeat_state_key, server_id)
+    if raw is None:
+        raise HTTPException(status_code=404, detail=f"Server '{server_id}' not found")
+    return _build_server_status(server_id, raw)

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,3 +3,5 @@ uvicorn[standard]
 pydantic
 pydantic-settings
 httpx
+redis[hiredis]
+clickhouse-connect


### PR DESCRIPTION
## Summary

- **`app/heartbeat.py`**: consumes `maestro:heartbeat` stream via `XREADGROUP`; writes server state to Redis hash `maestro:server_heartbeats` (field = `server_id`, value = JSON `{last_seen, agent_version}`); runs as an independent asyncio background task
- **`app/servers.py`**: `GET /servers` — all known servers with status; `GET /servers/{server_id}/status` — single server (404 if never seen); status computed at read time from `last_seen` vs `now()` using configurable `offline_threshold_seconds` (default: 90s)
- **`app/config.py`**: added `heartbeat_stream`, `heartbeat_consumer_group`, `heartbeat_state_key`, `offline_threshold_seconds`
- **`app/main.py`**: lifespan starts both `metrics-consumer` and `heartbeat-consumer` tasks; registers `servers_router`

> Note: also includes `app/consumer.py`, `app/clickhouse.py`, and updated `requirements.txt` from #6 (not yet on main).

## API

```
GET /servers
→ [{"server_id": "hostname", "status": "online", "last_seen": "...", "agent_version": "dev"}]

GET /servers/{server_id}/status
→ {"server_id": "hostname", "status": "offline", "last_seen": "...", "agent_version": "dev"}
→ 404 if server never sent a heartbeat
```

## Status logic

| Condition | Status |
|---|---|
| `last_seen` within 90s | `online` |
| `last_seen` older than 90s | `offline` |
| Server never seen | `unknown` (list) / 404 (single) |

## Test plan

- [ ] Agent running → `GET /servers` returns server with `status: online`
- [ ] Agent stopped 2+ minutes → `GET /servers/{id}/status` returns `status: offline`
- [ ] Unknown server → `GET /servers/{id}/status` returns 404
- [ ] `MAESTRO_OFFLINE_THRESHOLD_SECONDS=10` overrides threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)