### PR TITLE
fix(api): Python 3.9 compatibility

### DIFF
--- a/api/app/clickhouse.py
+++ b/api/app/clickhouse.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 from dataclasses import dataclass

--- a/api/app/consumer.py
+++ b/api/app/consumer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import json
 import logging

--- a/api/app/heartbeat.py
+++ b/api/app/heartbeat.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import json
 import logging

--- a/api/app/metrics.py
+++ b/api/app/metrics.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request

--- a/api/app/servers.py
+++ b/api/app/servers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 from datetime import datetime, timezone

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -5,3 +5,4 @@ pydantic-settings
 httpx
 redis[hiredis]
 clickhouse-connect
+async-timeout


### PR DESCRIPTION
- Add `from __future__ import annotations` to all api/app modules — enables `str | None` union syntax on Python 3.9
- Add `async-timeout` to requirements.txt — required by redis-py on Python < 3.11