### PR TITLE
fix(api): truncate RFC3339Nano timestamps for Python 3.9

### DIFF
--- a/api/app/consumer.py
+++ b/api/app/consumer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 from datetime import datetime, timezone
 
 import redis.asyncio as aioredis
@@ -17,6 +18,7 @@ def _parse_metric(raw: str) -> MetricRow | None:
     try:
         data = json.loads(raw)
         ts_raw = data["timestamp"].replace("Z", "+00:00")
+        ts_raw = re.sub(r"(\.\d{6})\d+", r"\1", ts_raw)
         timestamp = datetime.fromisoformat(ts_raw).astimezone(timezone.utc).replace(tzinfo=None)
         return MetricRow(
             server_id=data["server_id"],

--- a/api/app/heartbeat.py
+++ b/api/app/heartbeat.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 from datetime import datetime, timezone
 
 import redis.asyncio as aioredis
@@ -17,6 +18,7 @@ def _parse_heartbeat(raw: str) -> dict | None:
     try:
         data = json.loads(raw)
         ts_raw = data["timestamp"].replace("Z", "+00:00")
+        ts_raw = re.sub(r"(\.\d{6})\d+", r"\1", ts_raw)
         last_seen = datetime.fromisoformat(ts_raw).astimezone(timezone.utc)
         return {
             "server_id": data["server_id"],

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -6,3 +6,4 @@ httpx
 redis[hiredis]
 clickhouse-connect
 async-timeout
+eval-type-backport


### PR DESCRIPTION
## Summary

- Go's `time.Time.MarshalJSON` emits up to 9 fractional digits (RFC3339Nano), e.g. `2026-03-17T04:01:22.0106188Z`
- Python 3.9 `datetime.fromisoformat` only accepts 0, 3, or 6 fractional digits — causing all metrics and heartbeats to be dropped with a parse warning
- Fix: apply `re.sub(r"(\.\d{6})\d+", r"\1", ts_raw)` before `fromisoformat` in both `consumer.py` and `heartbeat.py`
- Also adds `eval-type-backport` to `requirements.txt` (needed for Pydantic union syntax on Python 3.9)

## Test plan

- [ ] Restart API (`uvicorn app.main:app ...`)
- [ ] Confirm no more `failed to parse metric` / `failed to parse payload` warnings in logs
- [ ] Confirm data flowing into ClickHouse (`SELECT count() FROM maestro.metrics`)
- [ ] Confirm `/servers` returns `"status": "online"` for active agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)