### PR TITLE
fix(api): async ClickHouse client init, env file path and timestamp normalization

### DIFF
--- a/api/app/clickhouse.py
+++ b/api/app/clickhouse.py
@@ -35,7 +35,10 @@ class ClickHouseWriter:
     """Async batch writer for the metrics table."""
 
     def __init__(self) -> None:
-        self._client = clickhouse_connect.get_async_client(
+        self._client = None
+
+    async def connect(self) -> None:
+        self._client = await clickhouse_connect.get_async_client(
             host=settings.clickhouse_host,
             port=settings.clickhouse_port,
             username=settings.clickhouse_user,
@@ -73,7 +76,8 @@ class ClickHouseWriter:
                 delay *= 2
 
     async def close(self) -> None:
-        await self._client.close()
+        if self._client is not None:
+            await self._client.close()
 
 
 # ── Reader ────────────────────────────────────────────────────────────────────
@@ -86,7 +90,10 @@ class ClickHouseReader:
     """
 
     def __init__(self) -> None:
-        self._client = clickhouse_connect.get_async_client(
+        self._client = None
+
+    async def connect(self) -> None:
+        self._client = await clickhouse_connect.get_async_client(
             host=settings.clickhouse_host,
             port=settings.clickhouse_port,
             username=settings.clickhouse_user,
@@ -133,4 +140,5 @@ class ClickHouseReader:
         return [DataPoint(timestamp=row[0], value=row[1]) for row in result.result_rows]
 
     async def close(self) -> None:
-        await self._client.close()
+        if self._client is not None:
+            await self._client.close()

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -1,4 +1,8 @@
+from pathlib import Path
+
 from pydantic_settings import BaseSettings
+
+_ENV_FILE = Path(__file__).parent.parent / ".env"
 
 
 class Settings(BaseSettings):
@@ -32,7 +36,7 @@ class Settings(BaseSettings):
     metrics_query_default_minutes: int = 30
     metrics_query_max_minutes: int = 1440  # 24 hours
 
-    model_config = {"env_prefix": "MAESTRO_", "env_file": "../api/.env", "env_file_encoding": "utf-8"}
+    model_config = {"env_prefix": "MAESTRO_", "env_file": str(_ENV_FILE), "env_file_encoding": "utf-8"}
 
 
 settings = Settings()

--- a/api/app/consumer.py
+++ b/api/app/consumer.py
@@ -18,7 +18,7 @@ def _parse_metric(raw: str) -> MetricRow | None:
     try:
         data = json.loads(raw)
         ts_raw = data["timestamp"].replace("Z", "+00:00")
-        ts_raw = re.sub(r"(\.\d{6})\d+", r"\1", ts_raw)
+        ts_raw = re.sub(r"\.(\d+)", lambda m: "." + (m.group(1) + "000000")[:6], ts_raw)
         timestamp = datetime.fromisoformat(ts_raw).astimezone(timezone.utc).replace(tzinfo=None)
         return MetricRow(
             server_id=data["server_id"],

--- a/api/app/heartbeat.py
+++ b/api/app/heartbeat.py
@@ -18,7 +18,7 @@ def _parse_heartbeat(raw: str) -> dict | None:
     try:
         data = json.loads(raw)
         ts_raw = data["timestamp"].replace("Z", "+00:00")
-        ts_raw = re.sub(r"(\.\d{6})\d+", r"\1", ts_raw)
+        ts_raw = re.sub(r"\.(\d+)", lambda m: "." + (m.group(1) + "000000")[:6], ts_raw)
         last_seen = datetime.fromisoformat(ts_raw).astimezone(timezone.utc)
         return {
             "server_id": data["server_id"],

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -22,6 +22,8 @@ async def lifespan(app: FastAPI):
     # Initialise shared resources.
     writer = ClickHouseWriter()
     reader = ClickHouseReader()
+    await writer.connect()
+    await reader.connect()
     app.state.ch_reader = reader
 
     # Start background consumers.

--- a/migrations/001_create_metrics.sql
+++ b/migrations/001_create_metrics.sql
@@ -18,7 +18,9 @@ CREATE TABLE IF NOT EXISTS maestro.metrics
     value       Float64,
 
     -- UTC timestamp at the moment of collection. Second-precision is sufficient for 5s+ intervals.
-    timestamp   DateTime,
+    -- Explicitly typed as DateTime('UTC') so ClickHouse always interprets values as UTC regardless
+    -- of the server's local timezone — critical for correct dashboard display and cross-system joins.
+    timestamp   DateTime('UTC'),
 
     -- Optional per-metric tags (e.g. device='sda', mount='/var', interface='eth0').
     -- Defaults to an empty map. Not part of the sort key — not suitable for high-cardinality filters.


### PR DESCRIPTION
## Summary

- **clickhouse.py**: `get_async_client()` movido para método `async connect()` — `__init__` não pode fazer `await`, causava atribuição de coroutine em vez do client real (`'coroutine' object has no attribute 'insert'`)
- **main.py**: `await writer.connect()` / `await reader.connect()` no lifespan antes de iniciar os consumers
- **config.py**: `env_file` resolvido via `Path(__file__)` — caminho relativo `../api/.env` quebrava dependendo do CWD do uvicorn
- **consumer.py / heartbeat.py**: regex de timestamp corrigido para normalizar qualquer número de dígitos fracionários para exatamente 6 (pad curto, trunca longo) — cobre saída RFC3339Nano do Go com 1–9 dígitos
- **migrations/001_create_metrics.sql**: `DateTime('UTC')` para que o ClickHouse sempre interprete valores inseridos como UTC, independente do timezone do servidor

## Test plan

- [x] API sobe sem erros
- [x] Métricas chegando no ClickHouse (`SELECT count() FROM maestro.metrics`)
- [x] Todos os tipos de métrica presentes: cpu, disk, network com tags corretas

Closes Phase 1 of Maestro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)