### PR TITLE
feat(frontend): connect dashboard to real API

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,36 +1,46 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useState } from 'react';
-import Dashboard from './components/Dashboard';
-import LogsExplorer from './components/LogsExplorer';
-import Infrastructure from './components/Infrastructure';
-import Security from './components/Security';
-import Alerts from './components/Alerts';
-import Settings from './components/Settings';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useState } from 'react'
+import Dashboard from './components/Dashboard'
+import LogsExplorer from './components/LogsExplorer'
+import Infrastructure from './components/Infrastructure'
+import Security from './components/Security'
+import Alerts from './components/Alerts'
+import Settings from './components/Settings'
+import ServerDashboard from './components/ServerDashboard'
+import { useUIStore } from './store/uiStore'
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient()
 
-export type ViewType = 'dashboard' | 'logs' | 'infrastructure' | 'security' | 'alerts' | 'settings';
+export type ViewType = 'dashboard' | 'logs' | 'infrastructure' | 'server' | 'security' | 'alerts' | 'settings'
 
-function App() {
-  const [currentView, setCurrentView] = useState<ViewType>('dashboard');
+function AppInner() {
+  const [currentView, setCurrentView] = useState<ViewType>('dashboard')
+  const selectedAgentId = useUIStore((s) => s.selectedAgentId)
 
   const renderView = () => {
     switch (currentView) {
-      case 'dashboard': return <Dashboard setView={setCurrentView} />;
-      case 'logs': return <LogsExplorer setView={setCurrentView} />;
-      case 'infrastructure': return <Infrastructure setView={setCurrentView} />;
-      case 'security': return <Security setView={setCurrentView} />;
-      case 'alerts': return <Alerts setView={setCurrentView} />;
-      case 'settings': return <Settings setView={setCurrentView} />;
-      default: return <Dashboard setView={setCurrentView} />;
+      case 'dashboard':      return <Dashboard setView={setCurrentView} />
+      case 'logs':           return <LogsExplorer setView={setCurrentView} />
+      case 'infrastructure': return <Infrastructure setView={setCurrentView} />
+      case 'server':         return selectedAgentId
+                               ? <ServerDashboard serverId={selectedAgentId} setView={setCurrentView} />
+                               : <Infrastructure setView={setCurrentView} />
+      case 'security':       return <Security setView={setCurrentView} />
+      case 'alerts':         return <Alerts setView={setCurrentView} />
+      case 'settings':       return <Settings setView={setCurrentView} />
+      default:               return <Dashboard setView={setCurrentView} />
     }
-  };
+  }
 
-  return (
-    <QueryClientProvider client={queryClient}>
-      {renderView()}
-    </QueryClientProvider>
-  );
+  return <>{renderView()}</>
 }
 
-export default App;
+function App() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AppInner />
+    </QueryClientProvider>
+  )
+}
+
+export default App

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,138 +1,109 @@
-import React from 'react';
-import ReactECharts from 'echarts-for-react';
-import * as echarts from 'echarts';
-import { useDashboardData } from '../hooks/useMetrics';
-import Layout from './Layout';
-import type { ViewType } from '../App';
-import {
-    Activity,
-    Terminal,
-    Shield,
-    Cpu,
-    Server
-} from 'lucide-react';
+import React from 'react'
+import { Activity, Shield, Server } from 'lucide-react'
+import Layout from './Layout'
+import type { ViewType } from '../App'
+import { useServers } from '../hooks/useServers'
+import { useUIStore } from '../store/uiStore'
 
 interface DashboardProps {
-    setView: (view: ViewType) => void;
+  setView: (view: ViewType) => void
 }
 
 const Dashboard: React.FC<DashboardProps> = ({ setView }) => {
-    const { data, isLoading, isError } = useDashboardData();
+  const { data: servers, isLoading } = useServers()
+  const setSelectedAgentId = useUIStore((s) => s.setSelectedAgentId)
 
-    if (isLoading) return <div className="p-8">Carregando Telemetria da Infraestrutura...</div>;
-    if (isError) return <div className="p-8 text-red-500">Erro na conexão com os agentes Maestro.</div>;
+  const online  = servers?.filter((s) => s.status === 'online').length  ?? 0
+  const offline = servers?.filter((s) => s.status === 'offline').length ?? 0
+  const total   = servers?.length ?? 0
 
-    const chartTheme = {
-        color: ['#39FF14', '#7C3AED'],
-        backgroundColor: 'transparent',
-        textStyle: { color: '#94A3B8' },
-        title: { textStyle: { color: '#F1F5F9' } },
-    };
-
-    const cpuOption = {
-        ...chartTheme,
-        tooltip: { trigger: 'axis', backgroundColor: '#1E293B', borderColor: '#7C3AED', textStyle: { color: '#F1F5F9' } },
-        grid: { left: '3%', right: '4%', bottom: '3%', containLabel: true },
-        xAxis: {
-            type: 'category',
-            boundaryGap: false,
-            data: data?.cpuUsage.map(m => new Date(m.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })),
-            axisLine: { lineStyle: { color: '#334155' } }
-        },
-        yAxis: { type: 'value', splitLine: { lineStyle: { color: '#1E293B' } } },
-        series: [
-            {
-                name: 'Aggregate Cluster CPU',
-                type: 'line',
-                smooth: true,
-                showSymbol: false,
-                data: data?.cpuUsage.map(m => m.value),
-                areaStyle: {
-                    color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
-                        { offset: 0, color: 'rgba(57, 255, 20, 0.3)' },
-                        { offset: 1, color: 'rgba(57, 255, 20, 0)' }
-                    ])
-                },
-                lineStyle: { width: 3, color: '#39FF14' }
-            }
-        ]
-    };
-
-    return (
-        <Layout currentView="dashboard" setView={setView} title="Observabilidade Geral">
-            <div className="space-y-8">
-                {/* Stats Row */}
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                    {[
-                        { label: 'Servidores Ativos', value: '42', delta: 'Cluster OK', icon: Server, color: 'text-brand-purple' },
-                        { label: 'Ingestão de Métricas', value: '1.2M/min', delta: '+5% load', icon: Activity, color: 'text-brand-neon' },
-                        { label: 'Incidentes Críticos', value: '0', delta: 'last 24h', icon: Shield, color: 'text-brand-neon' },
-                    ].map((stat) => (
-                        <div key={stat.label} className="glass-card p-6 border-l-4 border-l-brand-purple/50">
-                            <div className="flex justify-between items-start mb-2">
-                                <span className="text-slate-400 text-xs font-semibold uppercase tracking-wider">{stat.label}</span>
-                                <stat.icon className={`w-5 h-5 ${stat.color}`} />
-                            </div>
-                            <div className="flex items-baseline gap-2">
-                                <span className="text-2xl font-bold font-mono">{stat.value}</span>
-                                <span className="text-[10px] font-semibold text-brand-neon">{stat.delta}</span>
-                            </div>
-                        </div>
-                    ))}
-                </div>
-
-                {/* Charts Row */}
-                <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-                    <section className="glass-card p-6">
-                        <div className="flex justify-between items-center mb-6">
-                            <h3 className="font-semibold flex items-center gap-2 text-glow-neon">
-                                <Cpu className="w-4 h-4 text-brand-neon" />
-                                Carga de CPU (Infraestrutura On-Premise)
-                            </h3>
-                        </div>
-                        <div className="h-[300px]">
-                            <ReactECharts option={cpuOption} style={{ height: '100%', width: '100%' }} />
-                        </div>
-                    </section>
-
-                    <section className="glass-card p-6 flex flex-col">
-                        <div className="flex justify-between items-center mb-6">
-                            <h3 className="font-semibold flex items-center gap-2 text-glow-purple">
-                                <Terminal className="w-4 h-4 text-brand-purple" />
-                                Syslogs em Tempo Real
-                            </h3>
-                            <button
-                                onClick={() => setView('logs')}
-                                className="text-[10px] text-slate-500 hover:text-brand-purple transition-colors uppercase tracking-widest font-mono"
-                            >
-                                Ver Explorer
-                            </button>
-                        </div>
-                        <div className="flex-1 space-y-3 overflow-y-auto max-h-[300px] scrollbar-hide">
-                            {[
-                                { id: '1', host: 'srv-db-01', msg: 'PostgreSQL: vacuum scale factor reached', time: '17:01:22' },
-                                { id: '2', host: 'srv-app-04', msg: 'maestro-agent: successfully pushed 512 samples', time: '17:01:20' },
-                                { id: '3', host: 'srv-web-02', msg: 'nginx: 200 GET /api/v1/metrics', time: '17:01:15' },
-                                { id: '4', host: 'srv-db-01', msg: 'systemd: Started Daily apt download activities', time: '17:01:10' },
-                                { id: '5', host: 'srv-mon-01', msg: 'kernel: [ 124.5] TCP: request_sock_TCP: Possible SYN flood', time: '17:01:05' },
-                            ].map((log) => (
-                                <div key={log.id} className="p-3 bg-white/5 border border-white/5 rounded-lg hover:border-brand-purple/30 group transition-all">
-                                    <div className="flex justify-between items-center mb-1 text-[10px] font-mono">
-                                        <span className="text-brand-neon opacity-70 group-hover:opacity-100 font-bold">[{log.host}]</span>
-                                        <span className="text-slate-500">{log.time}</span>
-                                    </div>
-                                    <p className="text-xs font-mono text-slate-300 group-hover:text-slate-100 leading-tight">
-                                        {log.msg}
-                                    </p>
-                                </div>
-                            ))}
-                        </div>
-                    </section>
-                </div>
+  return (
+    <Layout currentView="dashboard" setView={setView} title="Observabilidade Geral">
+      <div className="space-y-8">
+        {/* Stats */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          <div className="glass-card p-6 border-l-4 border-l-brand-purple/50">
+            <div className="flex justify-between items-start mb-2">
+              <span className="text-slate-400 text-xs font-semibold uppercase tracking-wider">Servidores Ativos</span>
+              <Server className="w-5 h-5 text-brand-purple" />
             </div>
-        </Layout>
-    );
-};
+            <div className="flex items-baseline gap-2">
+              <span className="text-2xl font-bold font-mono">{isLoading ? '…' : online}</span>
+              {!isLoading && (
+                <span className="text-[10px] font-semibold text-slate-400">de {total} ({offline} offline)</span>
+              )}
+            </div>
+          </div>
 
-export default Dashboard;
+          <div className="glass-card p-6 border-l-4 border-l-brand-neon/50">
+            <div className="flex justify-between items-start mb-2">
+              <span className="text-slate-400 text-xs font-semibold uppercase tracking-wider">Agentes Online</span>
+              <Activity className="w-5 h-5 text-brand-neon" />
+            </div>
+            <div className="flex items-baseline gap-2">
+              <span className="text-2xl font-bold font-mono">{isLoading ? '…' : online}</span>
+              <span className="text-[10px] font-semibold text-brand-neon">coletando métricas</span>
+            </div>
+          </div>
 
+          <div className="glass-card p-6 border-l-4 border-l-brand-neon/50">
+            <div className="flex justify-between items-start mb-2">
+              <span className="text-slate-400 text-xs font-semibold uppercase tracking-wider">Incidentes Críticos</span>
+              <Shield className="w-5 h-5 text-brand-neon" />
+            </div>
+            <div className="flex items-baseline gap-2">
+              <span className="text-2xl font-bold font-mono">0</span>
+              <span className="text-[10px] font-semibold text-slate-400">last 24h</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Server list preview */}
+        <section className="glass-card p-6">
+          <div className="flex justify-between items-center mb-5">
+            <h3 className="font-semibold text-slate-200">Servidores</h3>
+            <button
+              onClick={() => setView('infrastructure')}
+              className="text-[10px] text-slate-500 hover:text-brand-purple transition-colors uppercase tracking-widest font-mono"
+            >
+              Ver todos
+            </button>
+          </div>
+
+          {isLoading && <p className="text-slate-500 text-sm">Carregando...</p>}
+
+          <div className="space-y-2">
+            {servers?.map((server) => (
+              <button
+                key={server.server_id}
+                onClick={() => {
+                  setSelectedAgentId(server.server_id)
+                  setView('server')
+                }}
+                className="w-full flex items-center justify-between p-3 bg-white/5 hover:bg-white/10 border border-white/5 rounded-lg transition-all text-left"
+              >
+                <div className="flex items-center gap-3">
+                  <span className={`w-2 h-2 rounded-full flex-shrink-0 ${
+                    server.status === 'online'  ? 'bg-emerald-400 shadow-[0_0_6px_rgba(52,211,153,0.8)]'
+                    : server.status === 'offline' ? 'bg-red-500'
+                    : 'bg-slate-500'
+                  }`} />
+                  <span className="text-sm font-mono">{server.server_id}</span>
+                </div>
+                <span className={`text-xs capitalize ${
+                  server.status === 'online'  ? 'text-emerald-400'
+                  : server.status === 'offline' ? 'text-red-400'
+                  : 'text-slate-400'
+                }`}>
+                  {server.status}
+                </span>
+              </button>
+            ))}
+          </div>
+        </section>
+      </div>
+    </Layout>
+  )
+}
+
+export default Dashboard

--- a/frontend/src/components/Infrastructure.tsx
+++ b/frontend/src/components/Infrastructure.tsx
@@ -1,93 +1,111 @@
-import React from 'react';
-import Layout from './Layout';
-import type { ViewType } from '../App';
-import { Server, Activity, Monitor, Network } from 'lucide-react';
+import React from 'react'
+import { Server, Network, Clock } from 'lucide-react'
+import Layout from './Layout'
+import type { ViewType } from '../App'
+import { useServers } from '../hooks/useServers'
+import { useUIStore } from '../store/uiStore'
+import type { ServerStatus } from '../types/server'
 
 interface InfrastructureProps {
-    setView: (view: ViewType) => void;
+  setView: (view: ViewType) => void
+}
+
+const statusDot: Record<ServerStatus['status'], string> = {
+  online:  'bg-emerald-400 shadow-[0_0_8px_rgba(52,211,153,0.8)]',
+  offline: 'bg-red-500',
+  unknown: 'bg-slate-500',
+}
+
+const statusBar: Record<ServerStatus['status'], string> = {
+  online:  'bg-emerald-400',
+  offline: 'bg-red-500',
+  unknown: 'bg-slate-600',
+}
+
+function timeAgo(iso: string | null): string {
+  if (!iso) return '—'
+  const diff = Math.floor((Date.now() - new Date(iso).getTime()) / 1000)
+  if (diff < 60) return `${diff}s atrás`
+  if (diff < 3600) return `${Math.floor(diff / 60)}m atrás`
+  return `${Math.floor(diff / 3600)}h atrás`
 }
 
 const Infrastructure: React.FC<InfrastructureProps> = ({ setView }) => {
-    const nodes = [
-        { id: 'SRV-DB-PROD-01', role: 'Database Master', load: 82, ram: 74, status: 'online', ip: '10.0.0.10' },
-        { id: 'SRV-APP-PROD-01', role: 'Application API', load: 45, ram: 58, status: 'online', ip: '10.0.0.21' },
-        { id: 'SRV-WEB-PROD-01', role: 'Nginx Load Balancer', load: 12, ram: 22, status: 'online', ip: '10.0.0.5' },
-        { id: 'SRV-MON-LOCAL-01', role: 'Maestro Aggregator', load: 92, ram: 88, status: 'warning', ip: '10.0.0.100' },
-    ];
+  const { data: servers, isLoading, isError } = useServers()
+  const setSelectedAgentId = useUIStore((s) => s.setSelectedAgentId)
 
-    return (
-        <Layout currentView="infrastructure" setView={setView} title="Mapa de Servidores">
-            <div className="space-y-4 mb-8">
-                <h2 className="text-xl font-bold flex items-center gap-2">
-                    <Network className="w-5 h-5 text-brand-purple" />
-                    Topologia On-Premise (Cluster Carvalima)
-                </h2>
-                <p className="text-slate-400 text-sm">Status detalhado dos recursos de hardware por host monitorado.</p>
+  const handleSelect = (serverId: string) => {
+    setSelectedAgentId(serverId)
+    setView('server')
+  }
+
+  return (
+    <Layout currentView="infrastructure" setView={setView} title="Mapa de Servidores">
+      <div className="space-y-4 mb-8">
+        <h2 className="text-xl font-bold flex items-center gap-2">
+          <Network className="w-5 h-5 text-brand-purple" />
+          Servidores Monitorados
+        </h2>
+        <p className="text-slate-400 text-sm">
+          Status em tempo real de todos os agentes Maestro registrados.
+        </p>
+      </div>
+
+      {isLoading && (
+        <p className="text-slate-400 text-sm">Carregando servidores...</p>
+      )}
+      {isError && (
+        <p className="text-red-400 text-sm">Erro ao carregar servidores.</p>
+      )}
+
+      {servers && servers.length === 0 && (
+        <div className="glass-card p-10 text-center">
+          <Server className="w-10 h-10 text-slate-600 mx-auto mb-3" />
+          <p className="text-slate-500 text-sm">Nenhum servidor registrado ainda.</p>
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+        {servers?.map((server) => (
+          <button
+            key={server.server_id}
+            onClick={() => handleSelect(server.server_id)}
+            className="glass-card p-5 relative overflow-hidden text-left group hover:border-brand-purple/40 transition-all"
+          >
+            <div className={`absolute top-0 right-0 w-1 h-full ${statusBar[server.status]}`} />
+
+            <div className="flex items-center gap-3 mb-4">
+              <div className="p-2 bg-brand-slate rounded-lg">
+                <Server className="w-4 h-4 text-brand-purple" />
+              </div>
+              <div className="min-w-0">
+                <h3 className="text-sm font-bold font-mono tracking-tight truncate">{server.server_id}</h3>
+                <span className="text-[10px] text-slate-500 uppercase">
+                  {server.agent_version ?? 'versão desconhecida'}
+                </span>
+              </div>
             </div>
 
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-                {nodes.map(node => (
-                    <div key={node.id} className="glass-card p-5 relative overflow-hidden group">
-                        <div className={`absolute top-0 right-0 w-1 h-full ${node.status === 'online' ? 'bg-brand-neon shadow-[0_0_10px_rgba(57,255,20,0.5)]' : 'bg-orange-500 ripple-orange'
-                            }`}></div>
-
-                        <div className="flex items-center gap-3 mb-4">
-                            <div className="p-2 bg-brand-slate rounded-lg">
-                                <Server className="w-4 h-4 text-brand-purple" />
-                            </div>
-                            <div>
-                                <h3 className="text-sm font-bold font-mono tracking-tight">{node.id}</h3>
-                                <span className="text-[10px] text-slate-500 uppercase">{node.role}</span>
-                            </div>
-                        </div>
-
-                        <div className="space-y-4">
-                            <div className="space-y-1">
-                                <div className="flex justify-between text-[10px]">
-                                    <span className="text-slate-400 uppercase font-bold">CPU Load</span>
-                                    <span className={`font-mono ${node.load > 90 ? 'text-red-400' : 'text-brand-neon'}`}>{node.load}%</span>
-                                </div>
-                                <div className="h-1 w-full bg-slate-700/50 rounded-full overflow-hidden">
-                                    <div
-                                        className={`h-full transition-all duration-1000 ${node.load > 90 ? 'bg-red-500' : 'bg-brand-neon'}`}
-                                        style={{ width: `${node.load}%` }}
-                                    ></div>
-                                </div>
-                            </div>
-
-                            <div className="space-y-1">
-                                <div className="flex justify-between text-[10px]">
-                                    <span className="text-slate-400 uppercase font-bold">RAM Usage</span>
-                                    <span className="font-mono text-brand-purple">{node.ram}%</span>
-                                </div>
-                                <div className="h-1 w-full bg-slate-700/50 rounded-full overflow-hidden">
-                                    <div
-                                        className="h-full bg-brand-purple transition-all duration-1000"
-                                        style={{ width: `${node.ram}%` }}
-                                    ></div>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div className="mt-6 pt-4 border-t border-white/5 flex justify-between items-center opacity-70 group-hover:opacity-100 transition-opacity font-mono text-[9px]">
-                            <div className="flex items-center gap-1.5">
-                                <Activity className="w-3 h-3 text-slate-500" />
-                                <span>Uptime: 12d 4h</span>
-                            </div>
-                            <span className="text-slate-500">{node.ip}</span>
-                        </div>
-                    </div>
-                ))}
+            <div className="flex items-center gap-2 mt-4">
+              <span className={`w-2 h-2 rounded-full flex-shrink-0 ${statusDot[server.status]}`} />
+              <span className={`text-xs font-semibold capitalize ${
+                server.status === 'online' ? 'text-emerald-400'
+                : server.status === 'offline' ? 'text-red-400'
+                : 'text-slate-400'
+              }`}>
+                {server.status}
+              </span>
             </div>
 
-            <div className="mt-12 glass-card p-8 flex items-center justify-center border-dashed border-2">
-                <div className="text-center space-y-2">
-                    <Monitor className="w-12 h-12 text-slate-700 mx-auto" />
-                    <p className="text-slate-500 text-sm italic">Visualização de Rack 3D em desenvolvimento...</p>
-                </div>
+            <div className="mt-3 pt-3 border-t border-white/5 flex items-center gap-1.5 font-mono text-[9px] text-slate-500 opacity-70 group-hover:opacity-100 transition-opacity">
+              <Clock className="w-3 h-3" />
+              <span>{timeAgo(server.last_seen)}</span>
             </div>
-        </Layout>
-    );
-};
+          </button>
+        ))}
+      </div>
+    </Layout>
+  )
+}
 
-export default Infrastructure;
+export default Infrastructure

--- a/frontend/src/components/MetricCard.tsx
+++ b/frontend/src/components/MetricCard.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import { TrendingUp, TrendingDown, Minus } from 'lucide-react'
+import type { DataPoint } from '../services/api'
+
+interface MetricCardProps {
+  label: string
+  unit: string
+  data: DataPoint[]
+  thresholds?: { amber: number; red: number }
+}
+
+function getTrend(data: DataPoint[]): 'up' | 'down' | 'stable' {
+  if (data.length < 2) return 'stable'
+  const half = Math.floor(data.length / 2)
+  const prev = data.slice(0, half).reduce((s, d) => s + d.value, 0) / half
+  const curr = data.slice(half).reduce((s, d) => s + d.value, 0) / (data.length - half)
+  const diff = curr - prev
+  if (Math.abs(diff) < prev * 0.02) return 'stable'
+  return diff > 0 ? 'up' : 'down'
+}
+
+function getSeverity(value: number, thresholds?: { amber: number; red: number }) {
+  if (!thresholds) return 'green'
+  if (value >= thresholds.red) return 'red'
+  if (value >= thresholds.amber) return 'amber'
+  return 'green'
+}
+
+const severityStyles = {
+  green: 'border-l-emerald-500 text-emerald-400',
+  amber: 'border-l-amber-400 text-amber-400',
+  red: 'border-l-red-500 text-red-400',
+}
+
+const MetricCard: React.FC<MetricCardProps> = ({ label, unit, data, thresholds }) => {
+  const current = data.at(-1)?.value ?? null
+  const trend = getTrend(data)
+  const severity = current !== null ? getSeverity(current, thresholds) : 'green'
+
+  const TrendIcon = trend === 'up' ? TrendingUp : trend === 'down' ? TrendingDown : Minus
+  const trendColor = trend === 'up' ? 'text-red-400' : trend === 'down' ? 'text-emerald-400' : 'text-slate-400'
+
+  return (
+    <div className={`glass-card p-5 border-l-4 ${severityStyles[severity]}`}>
+      <div className="flex justify-between items-start mb-3">
+        <span className="text-slate-400 text-xs font-semibold uppercase tracking-wider">{label}</span>
+        <TrendIcon className={`w-4 h-4 ${trendColor}`} />
+      </div>
+      <div className="flex items-baseline gap-1">
+        {current !== null ? (
+          <>
+            <span className="text-2xl font-bold font-mono">
+              {current.toFixed(1)}
+            </span>
+            <span className="text-xs text-slate-400">{unit}</span>
+          </>
+        ) : (
+          <span className="text-sm text-slate-500">—</span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default MetricCard

--- a/frontend/src/components/ServerDashboard.tsx
+++ b/frontend/src/components/ServerDashboard.tsx
@@ -1,0 +1,164 @@
+import React, { useState } from 'react'
+import ReactECharts from 'echarts-for-react'
+import * as echarts from 'echarts'
+import { ArrowLeft, RefreshCw } from 'lucide-react'
+import { useMetricNames, useMetricSeries } from '../hooks/useMetrics'
+import MetricCard from './MetricCard'
+import Layout from './Layout'
+import type { ViewType } from '../App'
+
+interface ServerDashboardProps {
+  serverId: string
+  setView: (view: ViewType) => void
+}
+
+const TIME_RANGES = [
+  { label: '15m', minutes: 15 },
+  { label: '1h', minutes: 60 },
+  { label: '6h', minutes: 360 },
+  { label: '24h', minutes: 1440 },
+]
+
+const METRIC_CONFIG: Record<string, { label: string; unit: string; color: string; thresholds?: { amber: number; red: number } }> = {
+  cpu_usage_percent:        { label: 'CPU',         unit: '%',      color: '#39FF14', thresholds: { amber: 70, red: 90 } },
+  memory_usage_percent:     { label: 'Memória',     unit: '%',      color: '#7C3AED', thresholds: { amber: 75, red: 90 } },
+  disk_usage_percent:       { label: 'Disco',       unit: '%',      color: '#F59E0B', thresholds: { amber: 80, red: 95 } },
+  disk_read_bytes_per_sec:  { label: 'Disco Leitura', unit: 'B/s', color: '#06B6D4' },
+  disk_write_bytes_per_sec: { label: 'Disco Escrita', unit: 'B/s', color: '#EC4899' },
+  net_bytes_recv_per_sec:   { label: 'Rede ↓',      unit: 'B/s',   color: '#10B981' },
+  net_bytes_sent_per_sec:   { label: 'Rede ↑',      unit: 'B/s',   color: '#F97316' },
+  process_count:            { label: 'Processos',   unit: '',       color: '#94A3B8' },
+}
+
+interface MetricChartProps {
+  serverId: string
+  metric: string
+  minutes: number
+}
+
+const MetricChart: React.FC<MetricChartProps> = ({ serverId, metric, minutes }) => {
+  const { data, isFetching } = useMetricSeries(serverId, metric, minutes)
+  const cfg = METRIC_CONFIG[metric] ?? { label: metric, unit: '', color: '#94A3B8' }
+
+  const option = {
+    backgroundColor: 'transparent',
+    tooltip: {
+      trigger: 'axis',
+      backgroundColor: '#1E293B',
+      borderColor: cfg.color,
+      textStyle: { color: '#F1F5F9', fontSize: 11 },
+    },
+    grid: { left: '3%', right: '4%', bottom: '3%', top: '8%', containLabel: true },
+    xAxis: {
+      type: 'category',
+      boundaryGap: false,
+      data: data?.data.map((p) => new Date(p.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })) ?? [],
+      axisLine: { lineStyle: { color: '#334155' } },
+      axisLabel: { color: '#64748B', fontSize: 10 },
+    },
+    yAxis: {
+      type: 'value',
+      splitLine: { lineStyle: { color: '#1E293B' } },
+      axisLabel: { color: '#64748B', fontSize: 10 },
+    },
+    series: [
+      {
+        name: cfg.label,
+        type: 'line',
+        smooth: true,
+        showSymbol: false,
+        data: data?.data.map((p) => p.value.toFixed(2)) ?? [],
+        areaStyle: {
+          color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
+            { offset: 0, color: `${cfg.color}33` },
+            { offset: 1, color: `${cfg.color}00` },
+          ]),
+        },
+        lineStyle: { width: 2, color: cfg.color },
+      },
+    ],
+  }
+
+  return (
+    <section className="glass-card p-5">
+      <div className="flex justify-between items-center mb-4">
+        <h3 className="text-sm font-semibold text-slate-300">{cfg.label}</h3>
+        {isFetching && <RefreshCw className="w-3 h-3 text-slate-500 animate-spin" />}
+      </div>
+      <div className="h-[200px]">
+        <ReactECharts option={option} style={{ height: '100%', width: '100%' }} />
+      </div>
+    </section>
+  )
+}
+
+const ServerDashboard: React.FC<ServerDashboardProps> = ({ serverId, setView }) => {
+  const [minutes, setMinutes] = useState(60)
+  const { data: metricNames } = useMetricNames(serverId)
+
+  const summaryMetrics = ['cpu_usage_percent', 'memory_usage_percent', 'disk_usage_percent', 'process_count']
+  const chartMetrics = metricNames?.metrics ?? Object.keys(METRIC_CONFIG)
+
+  return (
+    <Layout currentView="infrastructure" setView={setView} title={serverId}>
+      <div className="space-y-6">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <button
+            onClick={() => setView('infrastructure')}
+            className="flex items-center gap-2 text-sm text-slate-400 hover:text-slate-200 transition-colors"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Servidores
+          </button>
+          <div className="flex gap-1">
+            {TIME_RANGES.map((r) => (
+              <button
+                key={r.label}
+                onClick={() => setMinutes(r.minutes)}
+                className={`px-3 py-1 text-xs font-mono rounded transition-colors ${
+                  minutes === r.minutes
+                    ? 'bg-brand-purple text-white'
+                    : 'text-slate-400 hover:text-slate-200'
+                }`}
+              >
+                {r.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Summary Cards (#16) */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          {summaryMetrics.map((metric) => (
+            <SummaryCardWrapper key={metric} serverId={serverId} metric={metric} minutes={minutes} />
+          ))}
+        </div>
+
+        {/* Charts (#15) */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          {chartMetrics.map((metric) => (
+            <MetricChart key={metric} serverId={serverId} metric={metric} minutes={minutes} />
+          ))}
+        </div>
+      </div>
+    </Layout>
+  )
+}
+
+const SummaryCardWrapper: React.FC<{ serverId: string; metric: string; minutes: number }> = ({
+  serverId, metric, minutes,
+}) => {
+  const { data } = useMetricSeries(serverId, metric, minutes)
+  const cfg = METRIC_CONFIG[metric] ?? { label: metric, unit: '', color: '#94A3B8' }
+  return (
+    <MetricCard
+      label={cfg.label}
+      unit={cfg.unit}
+      data={data?.data ?? []}
+      thresholds={(cfg as typeof METRIC_CONFIG[string]).thresholds}
+    />
+  )
+}
+
+export default ServerDashboard

--- a/frontend/src/hooks/useMetrics.ts
+++ b/frontend/src/hooks/useMetrics.ts
@@ -1,40 +1,18 @@
-import { useQuery } from '@tanstack/react-query';
-import type { DashboardData } from '../types/metrics';
+import { useQuery } from '@tanstack/react-query'
+import { metricsApi } from '../services/api'
 
-// Simulated API call
-const fetchDashboardData = async (): Promise<DashboardData> => {
-    // In a real app, this would be an axios/fetch call to /api
-    return new Promise((resolve) => {
-        setTimeout(() => {
-            const now = new Date();
-            resolve({
-                cpuUsage: Array.from({ length: 10 }).map((_, i) => ({
-                    id: `cpu-${i}`,
-                    timestamp: new Date(now.getTime() - (9 - i) * 60000).toISOString(),
-                    name: 'cpu_usage',
-                    value: Math.random() * 100,
-                    tags: { core: 'all' }
-                })),
-                memoryUsage: Array.from({ length: 10 }).map((_, i) => ({
-                    id: `mem-${i}`,
-                    timestamp: new Date(now.getTime() - (9 - i) * 60000).toISOString(),
-                    name: 'memory_usage',
-                    value: 40 + Math.random() * 20,
-                    tags: { type: 'used' }
-                })),
-                recentLogs: [
-                    { id: '1', timestamp: now.toISOString(), level: 'info', message: 'Agent connected', source: 'agent-01' },
-                    { id: '2', timestamp: now.toISOString(), level: 'warn', message: 'High CPU usage detected', source: 'agent-02' }
-                ]
-            });
-        }, 500);
-    });
-};
+export const useMetricNames = (serverId: string) =>
+  useQuery({
+    queryKey: ['metric-names', serverId],
+    queryFn: () => metricsApi.names(serverId),
+    enabled: !!serverId,
+    staleTime: 60_000,
+  })
 
-export const useDashboardData = () => {
-    return useQuery({
-        queryKey: ['dashboardData'],
-        queryFn: fetchDashboardData,
-        refetchInterval: 5000,
-    });
-};
+export const useMetricSeries = (serverId: string, metric: string, minutes: number) =>
+  useQuery({
+    queryKey: ['metric-series', serverId, metric, minutes],
+    queryFn: () => metricsApi.series(serverId, metric, minutes),
+    enabled: !!serverId && !!metric,
+    refetchInterval: 30_000,
+  })

--- a/frontend/src/hooks/useServers.ts
+++ b/frontend/src/hooks/useServers.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query'
+import { serversApi } from '../services/api'
+
+export const useServers = () =>
+  useQuery({
+    queryKey: ['servers'],
+    queryFn: serversApi.list,
+    refetchInterval: 30_000,
+  })
+
+export const useServerStatus = (serverId: string) =>
+  useQuery({
+    queryKey: ['server', serverId],
+    queryFn: () => serversApi.status(serverId),
+    refetchInterval: 30_000,
+    enabled: !!serverId,
+  })

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,0 +1,37 @@
+import axios from 'axios'
+import type { ServerStatus } from '../types/server'
+
+const http = axios.create({ baseURL: '/api' })
+
+export interface DataPoint {
+  timestamp: string
+  value: number
+}
+
+export interface MetricSeries {
+  server_id: string
+  metric: string
+  minutes: number
+  data: DataPoint[]
+}
+
+export interface MetricNames {
+  server_id: string
+  metrics: string[]
+}
+
+export const serversApi = {
+  list: (): Promise<ServerStatus[]> =>
+    http.get<ServerStatus[]>('/servers').then((r) => r.data),
+  status: (serverId: string): Promise<ServerStatus> =>
+    http.get<ServerStatus>(`/servers/${serverId}/status`).then((r) => r.data),
+}
+
+export const metricsApi = {
+  names: (serverId: string): Promise<MetricNames> =>
+    http.get<MetricNames>(`/metrics/${serverId}`).then((r) => r.data),
+  series: (serverId: string, metric: string, minutes: number): Promise<MetricSeries> =>
+    http
+      .get<MetricSeries>(`/metrics/${serverId}/${metric}`, { params: { minutes } })
+      .then((r) => r.data),
+}

--- a/frontend/src/types/server.ts
+++ b/frontend/src/types/server.ts
@@ -1,0 +1,6 @@
+export interface ServerStatus {
+  server_id: string
+  status: 'online' | 'offline' | 'unknown'
+  last_seen: string | null
+  agent_version: string | null
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,7 +1,15 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary

- Replaced all mocked data with real API calls to FastAPI backend
- Added Vite dev proxy (`/api` → `http://localhost:8000`) for local development
- Server list (`Infrastructure`) now shows real agents with online/offline/unknown status from heartbeat data, polling every 30s
- New `ServerDashboard` component with ECharts time-series charts per metric and 15m/1h/6h/24h time range selector
- New `MetricCard` component with current value, trend indicator (↑↓→) and severity colour coding (green/amber/red)
- `Dashboard` overview replaced mocks with live server count and clickable server list

## Components Changed

- [ ] Agent (Go)
- [ ] API (Python)
- [x] Frontend (React)
- [x] Infra / Config

## Test Plan

- [ ] Go: `go test ./...` passando
- [ ] Python: testes passando
- [x] Frontend: `npm run type-check` passando
- [x] Testado manualmente (build limpo, sem erros TS)

## Notes

- ECharts chunk warning (~1.4MB) is expected — ECharts is the project's charting library. Code splitting can be addressed in a future perf issue.
- `useDashboardData` mock hook removed; `useMetrics` now exports `useMetricNames` and `useMetricSeries` backed by real endpoints.
- Navigation to per-server view uses existing `selectedAgentId` in Zustand store.

Closes #13
Closes #14
Closes #15
Closes #16