### PR TITLE
feat(logs): real-time log explorer with SSE streaming

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,13 @@ jobs:
           python3.14 -m venv /opt/maestro/api/.venv
           /opt/maestro/api/.venv/bin/pip install -r /opt/maestro/api/requirements.txt
 
+      - name: Executar migrations ClickHouse
+        run: |
+          for f in migrations/*.sql; do
+            echo "Running migration: $f"
+            clickhouse-client --multiquery < "$f"
+          done
+
       - name: Deploy frontend
         run: rsync -av --delete frontend/dist/ /opt/maestro/frontend/
 

--- a/agent/cmd/agent/main.go
+++ b/agent/cmd/agent/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/yuriPeixoto/maestro/agent/internal/collector"
 	"github.com/yuriPeixoto/maestro/agent/internal/config"
 	"github.com/yuriPeixoto/maestro/agent/internal/heartbeat"
+	"github.com/yuriPeixoto/maestro/agent/internal/logwatcher"
 	"github.com/yuriPeixoto/maestro/agent/internal/publisher"
 )
 
@@ -38,6 +39,17 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	// Log watcher — tails configured files and emits lines to Redis Streams.
+	// Returns the subset of paths that actually exist (passed to heartbeat).
+	watchedLogs := logwatcher.Start(ctx, logwatcher.Config{
+		ServerID:      cfg.ServerID,
+		Stream:        cfg.LogWatcher.Stream,
+		Paths:         cfg.LogWatcher.Paths,
+		RedisAddr:     cfg.Redis.Addr,
+		RedisPassword: cfg.Redis.Password,
+		Debug:         cfg.Debug,
+	})
+
 	// Heartbeat emitter — runs independently, failures never affect metric collection.
 	if err := heartbeat.Start(ctx, heartbeat.Config{
 		ServerID:      cfg.ServerID,
@@ -45,6 +57,7 @@ func main() {
 		Interval:      cfg.Heartbeat.Interval,
 		RedisAddr:     cfg.Redis.Addr,
 		RedisPassword: cfg.Redis.Password,
+		WatchedLogs:   watchedLogs,
 		Debug:         cfg.Debug,
 	}); err != nil {
 		log.Printf("warn: heartbeat emitter failed to start: %v — continuing without heartbeat", err)

--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -8,13 +8,21 @@ import (
 // Config holds all agent configuration. Values come from environment variables,
 // with sensible defaults so the agent works out of the box for local development.
 type Config struct {
-	ServerID  string
-	Redis     RedisConfig
-	Intervals IntervalConfig
-	Buffer    BufferConfig
-	Heartbeat HeartbeatConfig
+	ServerID   string
+	Redis      RedisConfig
+	Intervals  IntervalConfig
+	Buffer     BufferConfig
+	Heartbeat  HeartbeatConfig
+	LogWatcher LogWatcherConfig
 	// Debug prints metrics to stdout instead of Redis. Set MAESTRO_DEBUG=true.
 	Debug bool
+}
+
+// LogWatcherConfig controls which log files are tailed and where events go.
+type LogWatcherConfig struct {
+	Stream string
+	// Paths is the list of log file paths to watch. Files that do not exist are skipped silently.
+	Paths []string
 }
 
 // BufferConfig controls the in-memory ring buffer used when Redis is unavailable.
@@ -84,6 +92,11 @@ func Default() Config {
 		}
 	}
 
+	logStream := os.Getenv("MAESTRO_LOG_STREAM")
+	if logStream == "" {
+		logStream = "maestro:logs"
+	}
+
 	return Config{
 		ServerID: serverID,
 		Debug:    os.Getenv("MAESTRO_DEBUG") == "true",
@@ -107,6 +120,17 @@ func Default() Config {
 			DiskSpace:    60 * time.Second,
 			Network:      5 * time.Second,
 			ProcessCount: 30 * time.Second,
+		},
+		LogWatcher: LogWatcherConfig{
+			Stream: logStream,
+			Paths: []string{
+				"/var/log/syslog",
+				"/var/log/auth.log",
+				"/var/log/nginx/access.log",
+				"/var/log/nginx/error.log",
+				"/var/log/redis/redis-server.log",
+				"/var/log/clickhouse-server/clickhouse-server.log",
+			},
 		},
 	}
 }

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -19,6 +19,7 @@ type Payload struct {
 	ServerID     string    `json:"server_id"`
 	Timestamp    time.Time `json:"timestamp"`
 	AgentVersion string    `json:"agent_version"`
+	WatchedLogs  []string  `json:"watched_logs,omitempty"`
 }
 
 // Config holds all parameters needed by the emitter.
@@ -28,6 +29,7 @@ type Config struct {
 	Interval      time.Duration
 	RedisAddr     string
 	RedisPassword string
+	WatchedLogs   []string
 	Debug         bool
 }
 
@@ -85,6 +87,7 @@ func emit(ctx context.Context, cfg Config, client *redis.Client) {
 		ServerID:     cfg.ServerID,
 		Timestamp:    time.Now().UTC(),
 		AgentVersion: Version,
+		WatchedLogs:  cfg.WatchedLogs,
 	}
 
 	payload, err := json.Marshal(p)

--- a/agent/internal/logwatcher/watcher.go
+++ b/agent/internal/logwatcher/watcher.go
@@ -1,0 +1,174 @@
+package logwatcher
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const pollInterval = time.Second
+
+// Config holds parameters for the log watcher.
+type Config struct {
+	ServerID      string
+	Stream        string
+	Paths         []string
+	RedisAddr     string
+	RedisPassword string
+	Debug         bool
+}
+
+// Start launches one goroutine per log file and returns the list of paths that
+// actually exist on disk. Files that do not exist are skipped silently.
+func Start(ctx context.Context, cfg Config) []string {
+	var client *redis.Client
+	if !cfg.Debug {
+		client = redis.NewClient(&redis.Options{
+			Addr:     cfg.RedisAddr,
+			Password: cfg.RedisPassword,
+		})
+		pingCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		defer cancel()
+		if err := client.Ping(pingCtx).Err(); err != nil {
+			log.Printf("warn [logwatcher]: redis connection failed: %v — log streaming disabled", err)
+			return nil
+		}
+	}
+
+	var watching []string
+	for _, path := range cfg.Paths {
+		if _, err := os.Stat(path); err != nil {
+			continue // skip missing files silently
+		}
+		watching = append(watching, path)
+		go watch(ctx, client, cfg, path)
+	}
+
+	if len(watching) > 0 {
+		log.Printf("info [logwatcher]: watching %d file(s): %s", len(watching), strings.Join(watching, ", "))
+	}
+	return watching
+}
+
+// watch tails a single file, emitting new lines to Redis as they appear.
+// It handles log rotation by detecting when the file shrinks.
+func watch(ctx context.Context, client *redis.Client, cfg Config, path string) {
+	logName := logName(path)
+
+	f, offset, err := openAtEnd(path)
+	if err != nil {
+		log.Printf("warn [logwatcher]: cannot open %s: %v", path, err)
+		return
+	}
+	defer f.Close()
+
+	reader := bufio.NewReader(f)
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			fi, err := os.Stat(path)
+			if err != nil {
+				// File disappeared; wait and retry on the next tick.
+				continue
+			}
+
+			// Detect rotation: file shrank below our last offset.
+			if fi.Size() < offset {
+				f.Close()
+				f, err = os.Open(path)
+				if err != nil {
+					continue
+				}
+				reader.Reset(f)
+				offset = 0
+			}
+
+			lines, newOffset := readNewLines(reader, offset)
+			offset = newOffset
+
+			for _, line := range lines {
+				if line == "" {
+					continue
+				}
+				emit(ctx, client, cfg, logName, line)
+			}
+		}
+	}
+}
+
+// openAtEnd opens a file and seeks to the end so only future lines are tailed.
+func openAtEnd(path string) (*os.File, int64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, 0, err
+	}
+	offset, err := f.Seek(0, io.SeekEnd)
+	if err != nil {
+		f.Close()
+		return nil, 0, err
+	}
+	return f, offset, nil
+}
+
+// readNewLines reads all complete lines available from the reader and returns
+// them along with the new absolute byte offset.
+func readNewLines(reader *bufio.Reader, offset int64) ([]string, int64) {
+	var lines []string
+	for {
+		line, err := reader.ReadString('\n')
+		if len(line) > 0 {
+			offset += int64(len(line))
+			lines = append(lines, strings.TrimRight(line, "\n\r"))
+		}
+		if err != nil {
+			break
+		}
+	}
+	return lines, offset
+}
+
+// emit sends a single log line to Redis Streams (or stdout in debug mode).
+func emit(ctx context.Context, client *redis.Client, cfg Config, logName, line string) {
+	ts := time.Now().UTC().Format(time.RFC3339Nano)
+
+	if cfg.Debug {
+		log.Printf("debug [logwatcher] %s %s: %s", logName, ts, line)
+		return
+	}
+
+	err := client.XAdd(ctx, &redis.XAddArgs{
+		Stream: cfg.Stream,
+		Values: map[string]any{
+			"server_id": cfg.ServerID,
+			"log_file":  logName,
+			"timestamp": ts,
+			"line":      line,
+		},
+	}).Err()
+	if err != nil {
+		log.Printf("warn [logwatcher]: XADD failed for %s: %v", logName, err)
+	}
+}
+
+// logName derives a short, human-readable identifier from a full path.
+// /var/log/nginx/access.log → nginx/access.log
+// /var/log/syslog           → syslog
+func logName(path string) string {
+	const base = "/var/log/"
+	if strings.HasPrefix(path, base) {
+		return strings.TrimPrefix(path, base)
+	}
+	return filepath.Base(path)
+}

--- a/api/app/clickhouse.py
+++ b/api/app/clickhouse.py
@@ -12,6 +12,7 @@ from app.config import settings
 logger = logging.getLogger(__name__)
 
 _INSERT_COLUMNS = ["server_id", "metric_name", "value", "timestamp", "tags"]
+_LOG_INSERT_COLUMNS = ["server_id", "log_file", "timestamp", "line"]
 
 
 @dataclass
@@ -27,6 +28,14 @@ class MetricRow:
 class DataPoint:
     timestamp: datetime
     value: float
+
+
+@dataclass
+class LogRow:
+    server_id: str
+    log_file: str
+    timestamp: datetime
+    line: str
 
 
 # ── Writer ────────────────────────────────────────────────────────────────────
@@ -45,6 +54,28 @@ class ClickHouseWriter:
             password=settings.clickhouse_password,
             database=settings.clickhouse_database,
         )
+
+    async def insert_log_batch(self, rows: list[LogRow]) -> None:
+        if not rows:
+            return
+        data = [[r.server_id, r.log_file, r.timestamp, r.line] for r in rows]
+        delay = settings.consumer_retry_base_delay
+        for attempt in range(1, settings.consumer_retry_max + 1):
+            try:
+                await self._client.insert("logs", data=data, column_names=_LOG_INSERT_COLUMNS)
+                logger.debug("clickhouse: inserted %d log rows", len(rows))
+                return
+            except Exception as exc:
+                if attempt == settings.consumer_retry_max:
+                    logger.error(
+                        "clickhouse: log insert failed after %d attempts, dropping %d rows: %s",
+                        attempt, len(rows), exc,
+                    )
+                    return
+                logger.warning("clickhouse: log attempt %d/%d failed: %s — retrying in %.1fs",
+                               attempt, settings.consumer_retry_max, exc, delay)
+                await asyncio.sleep(delay)
+                delay *= 2
 
     async def insert_batch(self, rows: list[MetricRow]) -> None:
         if not rows:
@@ -138,6 +169,33 @@ class ClickHouseReader:
             },
         )
         return [DataPoint(timestamp=row[0], value=row[1]) for row in result.result_rows]
+
+    async def get_log_history(self, server_id: str, log_file: str, lines: int) -> list[LogRow]:
+        result = await self._client.query(
+            "SELECT server_id, log_file, timestamp, line"
+            " FROM logs"
+            " WHERE server_id = {server_id:String}"
+            "   AND log_file = {log_file:String}"
+            " ORDER BY timestamp DESC"
+            " LIMIT {lines:UInt32}",
+            parameters={"server_id": server_id, "log_file": log_file, "lines": lines},
+        )
+        rows = [LogRow(server_id=r[0], log_file=r[1], timestamp=r[2], line=r[3])
+                for r in reversed(result.result_rows)]
+        return rows
+
+    async def get_logs_since(self, server_id: str, log_file: str, since: datetime) -> list[LogRow]:
+        result = await self._client.query(
+            "SELECT server_id, log_file, timestamp, line"
+            " FROM logs"
+            " WHERE server_id = {server_id:String}"
+            "   AND log_file = {log_file:String}"
+            "   AND timestamp > {since:DateTime64(3)}"
+            " ORDER BY timestamp",
+            parameters={"server_id": server_id, "log_file": log_file, "since": since},
+        )
+        return [LogRow(server_id=r[0], log_file=r[1], timestamp=r[2], line=r[3])
+                for r in result.result_rows]
 
     async def close(self) -> None:
         if self._client is not None:

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -12,6 +12,11 @@ class Settings(BaseSettings):
     redis_consumer_group: str = "maestro-api"
     redis_consumer_name: str = "worker-1"
 
+    # Logs
+    log_stream: str = "maestro:logs"
+    log_consumer_group: str = "maestro-logs"
+    log_consumer_name: str = "log-worker-1"
+
     # Heartbeat
     heartbeat_stream: str = "maestro:heartbeat"
     heartbeat_consumer_group: str = "maestro-heartbeat"

--- a/api/app/heartbeat.py
+++ b/api/app/heartbeat.py
@@ -24,6 +24,7 @@ def _parse_heartbeat(raw: str) -> dict | None:
             "server_id": data["server_id"],
             "last_seen": last_seen.isoformat(),
             "agent_version": data.get("agent_version", "unknown"),
+            "watched_logs": data.get("watched_logs") or [],
         }
     except Exception as exc:
         logger.warning("heartbeat: failed to parse payload: %s — raw: %.200s", exc, raw)
@@ -64,6 +65,7 @@ async def run_heartbeat_consumer() -> None:
                         json.dumps({
                             "last_seen": parsed["last_seen"],
                             "agent_version": parsed["agent_version"],
+                            "watched_logs": parsed["watched_logs"],
                         }),
                     )
                     logger.debug("heartbeat: updated '%s' last_seen=%s", parsed["server_id"], parsed["last_seen"])

--- a/api/app/log_consumer.py
+++ b/api/app/log_consumer.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from datetime import datetime, timezone
+
+import redis.asyncio as aioredis
+
+from app.clickhouse import ClickHouseWriter, LogRow
+from app.config import settings
+from app.consumer import _ensure_group
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_log_event(fields: dict) -> LogRow | None:
+    try:
+        ts_raw = fields["timestamp"].replace("Z", "+00:00")
+        ts_raw = re.sub(r"\.(\d+)", lambda m: "." + (m.group(1) + "000000")[:6], ts_raw)
+        timestamp = datetime.fromisoformat(ts_raw).astimezone(timezone.utc).replace(tzinfo=None)
+        return LogRow(
+            server_id=fields["server_id"],
+            log_file=fields["log_file"],
+            timestamp=timestamp,
+            line=fields["line"],
+        )
+    except Exception as exc:
+        logger.warning("log_consumer: failed to parse event: %s — fields: %s", exc, fields)
+        return None
+
+
+async def run_log_consumer(writer: ClickHouseWriter) -> None:
+    redis = aioredis.from_url(settings.redis_url, decode_responses=True)
+    try:
+        await _ensure_group(redis, settings.log_stream, settings.log_consumer_group)
+        logger.info("log_consumer: listening on '%s' (group='%s')", settings.log_stream, settings.log_consumer_group)
+
+        while True:
+            try:
+                results = await redis.xreadgroup(
+                    groupname=settings.log_consumer_group,
+                    consumername=settings.log_consumer_name,
+                    streams={settings.log_stream: ">"},
+                    count=500,
+                    block=5000,
+                )
+            except aioredis.RedisError as exc:
+                logger.error("log_consumer: redis error: %s — retrying in 5s", exc)
+                await asyncio.sleep(5)
+                continue
+
+            if not results:
+                continue
+
+            _stream, messages = results[0]
+            rows, msg_ids = [], []
+            for msg_id, fields in messages:
+                row = _parse_log_event(fields)
+                if row is not None:
+                    rows.append(row)
+                msg_ids.append(msg_id)
+
+            if rows:
+                await writer.insert_log_batch(rows)
+            if msg_ids:
+                await redis.xack(settings.log_stream, settings.log_consumer_group, *msg_ids)
+                logger.debug("log_consumer: acked %d, inserted %d rows", len(msg_ids), len(rows))
+
+    except asyncio.CancelledError:
+        logger.info("log_consumer: shutting down")
+    finally:
+        await redis.aclose()

--- a/api/app/logs.py
+++ b/api/app/logs.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from datetime import datetime, timezone
+
+import redis.asyncio as aioredis
+from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+
+from app.clickhouse import ClickHouseReader
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/logs", tags=["logs"])
+
+
+class LogFilesResponse(BaseModel):
+    server_id: str
+    log_files: list[str]
+
+
+class LogLine(BaseModel):
+    server_id: str
+    log_file: str
+    timestamp: str
+    line: str
+
+
+class LogHistoryResponse(BaseModel):
+    server_id: str
+    log_file: str
+    lines: list[LogLine]
+
+
+@router.get("/{server_id}", response_model=LogFilesResponse)
+async def list_log_files(server_id: str) -> LogFilesResponse:
+    """Return the list of log files being watched by an agent (from latest heartbeat)."""
+    redis = aioredis.from_url(settings.redis_url, decode_responses=True)
+    try:
+        raw = await redis.hget(settings.heartbeat_state_key, server_id)
+    finally:
+        await redis.aclose()
+
+    if raw is None:
+        raise HTTPException(status_code=404, detail=f"Server '{server_id}' not found")
+
+    state = json.loads(raw)
+    return LogFilesResponse(server_id=server_id, log_files=state.get("watched_logs") or [])
+
+
+@router.get("/{server_id}/{log_file:path}/history", response_model=LogHistoryResponse)
+async def log_history(
+    server_id: str,
+    log_file: str,
+    request: Request,
+    lines: int = Query(default=200, ge=1, le=2000),
+) -> LogHistoryResponse:
+    """Return the last N lines for a server/log-file combination."""
+    reader: ClickHouseReader = request.app.state.ch_reader
+    rows = await reader.get_log_history(server_id, log_file, lines)
+    return LogHistoryResponse(
+        server_id=server_id,
+        log_file=log_file,
+        lines=[
+            LogLine(
+                server_id=r.server_id,
+                log_file=r.log_file,
+                timestamp=r.timestamp.isoformat() + "Z",
+                line=r.line,
+            )
+            for r in rows
+        ],
+    )
+
+
+@router.get("/{server_id}/{log_file:path}/stream")
+async def stream_logs(server_id: str, log_file: str, request: Request) -> StreamingResponse:
+    """SSE endpoint — streams new log lines in real-time by polling ClickHouse every second."""
+    reader: ClickHouseReader = request.app.state.ch_reader
+
+    async def event_generator():
+        last_ts = datetime.now(timezone.utc).replace(tzinfo=None)
+        while True:
+            if await request.is_disconnected():
+                break
+            try:
+                rows = await reader.get_logs_since(server_id, log_file, last_ts)
+                for row in rows:
+                    last_ts = row.timestamp
+                    payload = json.dumps({
+                        "server_id": row.server_id,
+                        "log_file": row.log_file,
+                        "timestamp": row.timestamp.isoformat() + "Z",
+                        "line": row.line,
+                    })
+                    yield f"data: {payload}\n\n"
+            except Exception as exc:
+                logger.warning("stream_logs: query error: %s", exc)
+            await asyncio.sleep(1)
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -7,6 +7,8 @@ from fastapi import FastAPI
 from app.clickhouse import ClickHouseReader, ClickHouseWriter
 from app.consumer import run_consumer
 from app.heartbeat import run_heartbeat_consumer
+from app.log_consumer import run_log_consumer
+from app.logs import router as logs_router
 from app.metrics import router as metrics_router
 from app.servers import router as servers_router
 
@@ -29,12 +31,13 @@ async def lifespan(app: FastAPI):
     # Start background consumers.
     metrics_task = asyncio.create_task(run_consumer(writer), name="metrics-consumer")
     heartbeat_task = asyncio.create_task(run_heartbeat_consumer(), name="heartbeat-consumer")
-    logger.info("app: metrics and heartbeat consumers started")
+    log_task = asyncio.create_task(run_log_consumer(writer), name="log-consumer")
+    logger.info("app: metrics, heartbeat and log consumers started")
 
     yield
 
     # Graceful shutdown.
-    for task in (metrics_task, heartbeat_task):
+    for task in (metrics_task, heartbeat_task, log_task):
         task.cancel()
         try:
             await task
@@ -50,6 +53,7 @@ app = FastAPI(title="Maestro API", lifespan=lifespan)
 
 app.include_router(servers_router)
 app.include_router(metrics_router)
+app.include_router(logs_router)
 
 
 @app.get("/")

--- a/frontend/src/components/LogsExplorer.tsx
+++ b/frontend/src/components/LogsExplorer.tsx
@@ -1,73 +1,235 @@
-import React, { useState } from 'react';
-import Layout from './Layout';
-import type { ViewType } from '../App';
-import { Search, Filter, Download, Terminal } from 'lucide-react';
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { Download, Filter, Terminal, Wifi, WifiOff, RefreshCw } from 'lucide-react'
+import Layout from './Layout'
+import type { ViewType } from '../App'
+import { useServers } from '../hooks/useServers'
+import { useLogFiles, useLogHistory, useLogStream, type StreamStatus } from '../hooks/useLogs'
+import type { LogLine } from '../services/api'
 
 interface LogsExplorerProps {
-    setView: (view: ViewType) => void;
+  setView: (view: ViewType) => void
 }
 
-const LogsExplorer: React.FC<LogsExplorerProps> = ({ setView }) => {
-    const [filter, setFilter] = useState('');
+function lineColor(line: string): string {
+  const u = line.toUpperCase()
+  if (/\b(CRIT|CRITICAL|FATAL|EMERG|ALERT)\b/.test(u)) return 'text-red-400'
+  if (/\b(ERROR|ERR)\b/.test(u)) return 'text-red-300'
+  if (/\bWARN(ING)?\b/.test(u)) return 'text-orange-400'
+  if (/\bINFO\b/.test(u)) return 'text-blue-400'
+  if (/\bDEBUG\b/.test(u)) return 'text-slate-500'
+  return 'text-slate-300'
+}
 
-    const mockLogs = [
-        { id: 1, time: '17:01:22', host: 'srv-db-01', service: 'postgresql', level: 'INFO', message: 'checkpoint complete: wrote 43 buffers (0.1%); LSN=0/19A2B40' },
-        { id: 2, time: '17:01:21', host: 'srv-app-04', service: 'maestro', level: 'INFO', message: 'successfully pushed 1024 metric samples to aggregator' },
-        { id: 3, time: '17:01:19', host: 'srv-web-02', service: 'nginx', level: 'WARN', message: '404 GET /wp-login.php from 192.168.1.45' },
-        { id: 4, time: '17:01:15', host: 'srv-auth-01', service: 'sshd', level: 'CRIT', message: 'Failed password for invalid user admin from 203.0.113.1 port 54322 ssh2' },
-        { id: 5, time: '17:01:10', host: 'srv-mon-01', service: 'kernel', level: 'WARN', message: '[ 842.1] TCP: request_sock_TCP: Possible SYN flood on port 80' },
-        { id: 6, time: '17:00:55', host: 'srv-db-01', service: 'systemd', level: 'INFO', message: 'Started Daily rotation of log files.' },
-    ];
+function StatusDot({ status }: { status: StreamStatus }) {
+  if (status === 'connected')
+    return <Wifi className="w-3 h-3 text-brand-neon" />
+  if (status === 'reconnecting')
+    return <RefreshCw className="w-3 h-3 text-orange-400 animate-spin" />
+  return <WifiOff className="w-3 h-3 text-slate-500" />
+}
 
-    return (
-        <Layout currentView="logs" setView={setView} title="Explorer de Syslogs">
-            <div className="glass-card flex flex-col h-[700px]">
-                {/* Toolbar */}
-                <div className="p-4 border-b border-white/5 flex items-center justify-between bg-brand-dark/20">
-                    <div className="flex items-center gap-4 flex-1">
-                        <div className="relative w-96">
-                            <Search className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-slate-500" />
-                            <input
-                                type="text"
-                                placeholder="Filtrar por Host, Serviço ou Mensagem..."
-                                className="w-full bg-brand-dark border border-white/10 rounded px-9 py-1.5 text-sm focus:outline-none focus:border-brand-purple/50"
-                                value={filter}
-                                onChange={(e) => setFilter(e.target.value)}
-                            />
-                        </div>
-                        <button className="flex items-center gap-2 bg-white/5 hover:bg-white/10 px-3 py-1.5 rounded border border-white/10 transition-all">
-                            <Filter className="w-4 h-4 text-brand-purple" />
-                            <span className="text-xs">Filtros Avançados</span>
-                        </button>
-                    </div>
-                    <button className="flex items-center gap-2 text-slate-400 hover:text-white transition-colors">
-                        <Download className="w-4 h-4" />
-                        <span className="text-xs">Exportar Logs (.log)</span>
-                    </button>
-                </div>
+interface LogStreamProps {
+  serverId: string
+  logFile: string
+  initialLines: LogLine[]
+  filter: string
+}
 
-                {/* Console Log Area */}
-                <div className="flex-1 overflow-y-auto p-4 font-mono text-sm bg-black/20">
-                    <div className="space-y-1">
-                        {mockLogs.map(log => (
-                            <div key={log.id} className="group flex gap-4 py-1 hover:bg-white/5 rounded px-2 transition-all cursor-default">
-                                <span className="text-slate-600 shrink-0">[{log.time}]</span>
-                                <span className={`shrink-0 w-12 font-bold ${log.level === 'CRIT' ? 'text-red-500' : log.level === 'WARN' ? 'text-orange-400' : 'text-blue-400'
-                                    }`}>{log.level}</span>
-                                <span className="text-brand-purple shrink-0 font-bold">{log.host}</span>
-                                <span className="text-brand-neon shrink-0 tracking-tighter opacity-80">&lt;{log.service}&gt;</span>
-                                <span className="text-slate-300 truncate group-hover:text-white transition-colors">{log.message}</span>
-                            </div>
-                        ))}
-                        <div className="py-2 border-t border-white/5 mt-4 flex items-center gap-3">
-                            <Terminal className="w-4 h-4 text-brand-neon animate-pulse" />
-                            <span className="text-brand-neon text-xs animate-pulse tracking-widest uppercase">Escutando logs da infraestrutura Carvalima...</span>
-                        </div>
-                    </div>
-                </div>
+function LogStream({ serverId, logFile, initialLines, filter }: LogStreamProps) {
+  const { lines: streamLines, status } = useLogStream(serverId, logFile, true)
+  const allLines = useMemo(
+    () => [...initialLines, ...streamLines].slice(-2000),
+    [initialLines, streamLines],
+  )
+  const filtered = filter
+    ? allLines.filter((l) => l.line.toLowerCase().includes(filter.toLowerCase()))
+    : allLines
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 px-3 py-1.5 border-b border-white/5 bg-white/3 text-xs font-mono">
+        <StatusDot status={status} />
+        <span className="text-slate-400">{logFile}</span>
+        <span className="ml-auto text-slate-600">{filtered.length} lines</span>
+      </div>
+      <div className="space-y-0">
+        {filtered.map((l, i) => (
+          <div
+            key={`${l.timestamp}-${i}`}
+            className="flex gap-3 px-3 py-0.5 hover:bg-white/3 transition-colors group"
+          >
+            <span className="text-slate-600 shrink-0 text-xs pt-0.5">
+              {new Date(l.timestamp).toLocaleTimeString('pt-BR', { hour12: false })}
+            </span>
+            <span className={`text-xs font-mono break-all ${lineColor(l.line)}`}>{l.line}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default function LogsExplorer({ setView }: LogsExplorerProps) {
+  const [selectedServer, setSelectedServer] = useState('')
+  const [selectedFiles, setSelectedFiles] = useState<string[]>([])
+  const [filter, setFilter] = useState('')
+  const bottomRef = useRef<HTMLDivElement>(null)
+
+  const { data: servers } = useServers()
+  const { data: logFilesData } = useLogFiles(selectedServer)
+  const { data: historyData } = useLogHistory(
+    selectedServer,
+    selectedFiles[0] ?? '',
+    200,
+  )
+
+  useEffect(() => {
+    if (servers && servers.length > 0 && !selectedServer) {
+      setSelectedServer(servers[0].server_id)
+    }
+  }, [servers, selectedServer])
+
+  useEffect(() => {
+    setSelectedFiles([])
+  }, [selectedServer])
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [historyData])
+
+  const toggleFile = (file: string) => {
+    setSelectedFiles((prev) =>
+      prev.includes(file) ? prev.filter((f) => f !== file) : [...prev, file],
+    )
+  }
+
+  const exportLogs = () => {
+    const content = (historyData?.lines ?? [])
+      .map((l) => `[${l.timestamp}] [${l.log_file}] ${l.line}`)
+      .join('\n')
+    const blob = new Blob([content], { type: 'text/plain' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `${selectedServer}-logs.log`
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  const availableFiles = logFilesData?.log_files ?? []
+  const hasSelection = selectedFiles.length > 0
+
+  return (
+    <Layout currentView="logs" setView={setView} title="Log Explorer">
+      <div className="flex gap-4 h-[calc(100vh-10rem)]">
+
+        {/* Sidebar: server + file selector */}
+        <div className="w-56 shrink-0 flex flex-col gap-3">
+          <div className="glass-card p-3">
+            <p className="text-xs text-slate-500 uppercase tracking-widest mb-2">Servidor</p>
+            <select
+              value={selectedServer}
+              onChange={(e) => setSelectedServer(e.target.value)}
+              className="w-full bg-brand-dark border border-white/10 rounded px-2 py-1.5 text-sm focus:outline-none focus:border-brand-purple/50"
+            >
+              {(servers ?? []).map((s) => (
+                <option key={s.server_id} value={s.server_id}>
+                  {s.server_id}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="glass-card p-3 flex-1 overflow-y-auto">
+            <p className="text-xs text-slate-500 uppercase tracking-widest mb-2">Arquivos</p>
+            {availableFiles.length === 0 && (
+              <p className="text-xs text-slate-600 italic">
+                {selectedServer ? 'Nenhum log disponível' : 'Selecione um servidor'}
+              </p>
+            )}
+            <div className="space-y-1">
+              {availableFiles.map((file) => (
+                <label
+                  key={file}
+                  className="flex items-center gap-2 cursor-pointer group py-0.5"
+                >
+                  <input
+                    type="checkbox"
+                    checked={selectedFiles.includes(file)}
+                    onChange={() => toggleFile(file)}
+                    className="accent-brand-purple"
+                  />
+                  <span className={`text-xs font-mono truncate group-hover:text-white transition-colors ${selectedFiles.includes(file) ? 'text-white' : 'text-slate-400'}`}>
+                    {file}
+                  </span>
+                </label>
+              ))}
             </div>
-        </Layout>
-    );
-};
+          </div>
+        </div>
 
-export default LogsExplorer;
+        {/* Terminal panel */}
+        <div className="flex-1 glass-card flex flex-col min-w-0">
+          {/* Toolbar */}
+          <div className="p-3 border-b border-white/5 flex items-center gap-3 shrink-0">
+            <div className="relative flex-1">
+              <Filter className="w-3.5 h-3.5 absolute left-2.5 top-1/2 -translate-y-1/2 text-slate-500" />
+              <input
+                type="text"
+                placeholder="Filtrar linhas..."
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+                className="w-full bg-brand-dark border border-white/10 rounded pl-8 pr-3 py-1.5 text-xs font-mono focus:outline-none focus:border-brand-purple/50"
+              />
+            </div>
+            <button
+              onClick={exportLogs}
+              disabled={!hasSelection}
+              className="flex items-center gap-1.5 text-xs text-slate-400 hover:text-white disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            >
+              <Download className="w-3.5 h-3.5" />
+              Exportar
+            </button>
+          </div>
+
+          {/* Log output */}
+          <div className="flex-1 overflow-y-auto bg-black/30 font-mono text-xs">
+            {!hasSelection ? (
+              <div className="h-full flex items-center justify-center text-slate-600">
+                <div className="text-center">
+                  <Terminal className="w-8 h-8 mx-auto mb-2 opacity-30" />
+                  <p>Selecione um ou mais arquivos de log</p>
+                </div>
+              </div>
+            ) : (
+              <div className="divide-y divide-white/3">
+                {selectedFiles.map((file) => (
+                  <LogStream
+                    key={file}
+                    serverId={selectedServer}
+                    logFile={file}
+                    initialLines={
+                      selectedFiles[0] === file ? (historyData?.lines ?? []) : []
+                    }
+                    filter={filter}
+                  />
+                ))}
+              </div>
+            )}
+            <div ref={bottomRef} />
+          </div>
+
+          {/* Status bar */}
+          <div className="px-3 py-1.5 border-t border-white/5 flex items-center gap-3 shrink-0">
+            <Terminal className="w-3 h-3 text-brand-neon animate-pulse" />
+            <span className="text-xs font-mono text-brand-neon tracking-widest uppercase">
+              {hasSelection
+                ? `Watching ${selectedFiles.length} file(s) on ${selectedServer}`
+                : 'Ready'}
+            </span>
+          </div>
+        </div>
+      </div>
+    </Layout>
+  )
+}

--- a/frontend/src/hooks/useLogs.ts
+++ b/frontend/src/hooks/useLogs.ts
@@ -1,0 +1,72 @@
+import { useEffect, useRef, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { logsApi, type LogLine } from '../services/api'
+
+export const useLogFiles = (serverId: string) =>
+  useQuery({
+    queryKey: ['log-files', serverId],
+    queryFn: () => logsApi.files(serverId),
+    enabled: !!serverId,
+    staleTime: 30_000,
+  })
+
+export const useLogHistory = (serverId: string, logFile: string, lines = 200) =>
+  useQuery({
+    queryKey: ['log-history', serverId, logFile, lines],
+    queryFn: () => logsApi.history(serverId, logFile, lines),
+    enabled: !!serverId && !!logFile,
+  })
+
+export type StreamStatus = 'connecting' | 'connected' | 'reconnecting' | 'error'
+
+export const useLogStream = (serverId: string, logFile: string, enabled: boolean) => {
+  const [lines, setLines] = useState<LogLine[]>([])
+  const [status, setStatus] = useState<StreamStatus>('connecting')
+  const esRef = useRef<EventSource | null>(null)
+  const retryRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (!enabled || !serverId || !logFile) return
+
+    let cancelled = false
+
+    const connect = () => {
+      if (cancelled) return
+      setStatus('connecting')
+      const url = `/api/logs/${serverId}/${logFile}/stream`
+      const es = new EventSource(url)
+      esRef.current = es
+
+      es.onopen = () => {
+        if (!cancelled) setStatus('connected')
+      }
+
+      es.onmessage = (event) => {
+        if (cancelled) return
+        try {
+          const parsed: LogLine = JSON.parse(event.data)
+          setLines((prev) => [...prev.slice(-1999), parsed])
+        } catch {
+          // malformed event — skip
+        }
+      }
+
+      es.onerror = () => {
+        es.close()
+        if (cancelled) return
+        setStatus('reconnecting')
+        retryRef.current = setTimeout(connect, 3000)
+      }
+    }
+
+    connect()
+
+    return () => {
+      cancelled = true
+      esRef.current?.close()
+      if (retryRef.current) clearTimeout(retryRef.current)
+    }
+  }, [serverId, logFile, enabled])
+
+  return { lines, status }
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -35,3 +35,30 @@ export const metricsApi = {
       .get<MetricSeries>(`/metrics/${serverId}/${metric}`, { params: { minutes } })
       .then((r) => r.data),
 }
+
+export interface LogFilesResponse {
+  server_id: string
+  log_files: string[]
+}
+
+export interface LogLine {
+  server_id: string
+  log_file: string
+  timestamp: string
+  line: string
+}
+
+export interface LogHistoryResponse {
+  server_id: string
+  log_file: string
+  lines: LogLine[]
+}
+
+export const logsApi = {
+  files: (serverId: string): Promise<LogFilesResponse> =>
+    http.get<LogFilesResponse>(`/logs/${serverId}`).then((r) => r.data),
+  history: (serverId: string, logFile: string, lines = 200): Promise<LogHistoryResponse> =>
+    http
+      .get<LogHistoryResponse>(`/logs/${serverId}/${logFile}/history`, { params: { lines } })
+      .then((r) => r.data),
+}

--- a/migrations/002_create_logs.sql
+++ b/migrations/002_create_logs.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS maestro.logs
+(
+    server_id  LowCardinality(String),
+    log_file   LowCardinality(String),
+    timestamp  DateTime64(3, 'UTC'),
+    line       String
+)
+ENGINE = MergeTree()
+PARTITION BY toYYYYMM(timestamp)
+ORDER BY (server_id, log_file, timestamp)
+TTL timestamp + INTERVAL 30 DAY
+SETTINGS index_granularity = 8192;


### PR DESCRIPTION
## Summary

- **Agent (Go)**: novo módulo `logwatcher` que faz tail de arquivos configurados (`/var/log/syslog`, `auth.log`, nginx, redis, clickhouse) e emite linhas para Redis Stream `maestro:logs`; heartbeat agora inclui campo `watched_logs` com os arquivos ativamente monitorados
- **Infra**: migration `002_create_logs.sql` — tabela `maestro.logs` com TTL 30 dias, particionada por mês; deploy workflow atualizado para executar migrations automaticamente a cada deploy
- **API (Python)**: consumer `log_consumer.py` que drena `maestro:logs` → ClickHouse em batch; router `logs.py` com 3 endpoints — listagem de arquivos, histórico e SSE streaming em tempo real
- **Frontend (React)**: `LogsExplorer` reescrito — selector de servidor/arquivo (multi-select), carrega histórico via REST e streama novas linhas via `EventSource`; color-coding por severity, filtro client-side, export `.log`

## Components Changed

- [x] Agent (Go)
- [x] API (Python)
- [x] Frontend (React)
- [x] Infra / Config

## Test Plan

- [x] Go: `go vet ./...` e `go test ./...` passando
- [ ] Python: sem suite de testes ainda
- [x] Frontend: `tsc --noEmit` sem erros
- [ ] Testado manualmente (requer merge + deploy para validar SSE no servidor)

## Notes

- Migrations usam `IF NOT EXISTS` — seguro executar repetidamente no deploy
- O step de migration roda `clickhouse-client --multiquery < *.sql` para cada arquivo em ordem
- SSE reconecta automaticamente em caso de queda (retry com 3s de backoff no hook `useLogStream`)
- Logs ficam 30 dias no ClickHouse (menor TTL que métricas, por volume)

Closes #51, #52, #53, #54