### PR TITLE
feat(security): real-time SSH audit log and brute-force stats from auth.log

### DIFF
--- a/api/app/clickhouse.py
+++ b/api/app/clickhouse.py
@@ -38,6 +38,14 @@ class LogRow:
     line: str
 
 
+@dataclass
+class SshStats:
+    attempts_1h: int
+    attempts_24h: int
+    unique_ips_24h: int
+    top_target: str | None
+
+
 # ── Writer ────────────────────────────────────────────────────────────────────
 
 class ClickHouseWriter:
@@ -196,6 +204,46 @@ class ClickHouseReader:
         )
         return [LogRow(server_id=r[0], log_file=r[1], timestamp=r[2], line=r[3])
                 for r in result.result_rows]
+
+    async def get_ssh_stats(self, server_id: str) -> SshStats:
+        q_1h, q_24h, q_ips, q_top = await asyncio.gather(
+            self._client.query(
+                "SELECT count() FROM logs"
+                " WHERE server_id = {s:String} AND log_file = 'auth.log'"
+                "   AND timestamp >= now() - INTERVAL 1 HOUR"
+                "   AND match(line, 'Failed password|Invalid user')",
+                parameters={"s": server_id},
+            ),
+            self._client.query(
+                "SELECT count() FROM logs"
+                " WHERE server_id = {s:String} AND log_file = 'auth.log'"
+                "   AND timestamp >= now() - INTERVAL 24 HOUR"
+                "   AND match(line, 'Failed password|Invalid user')",
+                parameters={"s": server_id},
+            ),
+            self._client.query(
+                "SELECT count(DISTINCT extract(line, 'from (\\\\S+) port')) FROM logs"
+                " WHERE server_id = {s:String} AND log_file = 'auth.log'"
+                "   AND timestamp >= now() - INTERVAL 24 HOUR"
+                "   AND match(line, 'Failed password|Invalid user')",
+                parameters={"s": server_id},
+            ),
+            self._client.query(
+                "SELECT extract(line, 'for (?:invalid user )?(\\\\S+) from') AS u, count() AS cnt"
+                " FROM logs"
+                " WHERE server_id = {s:String} AND log_file = 'auth.log'"
+                "   AND timestamp >= now() - INTERVAL 24 HOUR"
+                "   AND match(line, 'Failed password|Invalid user')"
+                " GROUP BY u ORDER BY cnt DESC LIMIT 1",
+                parameters={"s": server_id},
+            ),
+        )
+        return SshStats(
+            attempts_1h=q_1h.result_rows[0][0] if q_1h.result_rows else 0,
+            attempts_24h=q_24h.result_rows[0][0] if q_24h.result_rows else 0,
+            unique_ips_24h=q_ips.result_rows[0][0] if q_ips.result_rows else 0,
+            top_target=q_top.result_rows[0][0] if q_top.result_rows else None,
+        )
 
     async def close(self) -> None:
         if self._client is not None:

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -10,6 +10,7 @@ from app.heartbeat import run_heartbeat_consumer
 from app.log_consumer import run_log_consumer
 from app.logs import router as logs_router
 from app.metrics import router as metrics_router
+from app.security import router as security_router
 from app.servers import router as servers_router
 
 logging.basicConfig(
@@ -54,6 +55,7 @@ app = FastAPI(title="Maestro API", lifespan=lifespan)
 app.include_router(servers_router)
 app.include_router(metrics_router)
 app.include_router(logs_router)
+app.include_router(security_router)
 
 
 @app.get("/")

--- a/api/app/security.py
+++ b/api/app/security.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+from app.clickhouse import ClickHouseReader, SshStats
+from app.logs import _utc_iso
+
+router = APIRouter(prefix="/security", tags=["security"])
+
+# ── Regex patterns ─────────────────────────────────────────────────────────────
+
+_FAILED = re.compile(r"Failed password for (?:invalid user )?(\S+) from (\S+) port")
+_INVALID = re.compile(r"Invalid user (\S+) from (\S+)")
+_ACCEPTED = re.compile(r"Accepted (?:publickey|password) for (\S+) from (\S+)")
+_CLOSED = re.compile(r"Connection closed by (?:authenticating user |invalid user )?(\S+) (\S+) port")
+
+
+def _classify(ts: str, line: str) -> dict | None:
+    m = _FAILED.search(line)
+    if m:
+        return {"timestamp": ts, "type": "SSH", "action": "Failed Login",
+                "username": m.group(1), "source_ip": m.group(2), "result": "Blocked"}
+    m = _INVALID.search(line)
+    if m:
+        return {"timestamp": ts, "type": "SSH", "action": "Invalid User",
+                "username": m.group(1), "source_ip": m.group(2), "result": "Dropped"}
+    m = _ACCEPTED.search(line)
+    if m:
+        return {"timestamp": ts, "type": "AUTH", "action": "Login Accepted",
+                "username": m.group(1), "source_ip": m.group(2), "result": "Success"}
+    m = _CLOSED.search(line)
+    if m:
+        return {"timestamp": ts, "type": "SSH", "action": "Connection Closed",
+                "username": m.group(1), "source_ip": m.group(2), "result": "Dropped"}
+    return None
+
+
+# ── Response models ────────────────────────────────────────────────────────────
+
+class SshEvent(BaseModel):
+    timestamp: str
+    type: str
+    action: str
+    username: str
+    source_ip: str
+    result: str
+
+
+class SshStatsOut(BaseModel):
+    attempts_1h: int
+    attempts_24h: int
+    unique_ips_24h: int
+    top_target: str | None
+
+
+class SshEventsResponse(BaseModel):
+    server_id: str
+    stats: SshStatsOut
+    events: list[SshEvent]
+
+
+# ── Route ──────────────────────────────────────────────────────────────────────
+
+@router.get("/{server_id}/ssh-events", response_model=SshEventsResponse)
+async def ssh_events(server_id: str, request: Request) -> SshEventsResponse:
+    reader: ClickHouseReader = request.app.state.ch_reader
+
+    raw_rows, stats = await _fetch(reader, server_id)
+
+    events: list[SshEvent] = []
+    for row in raw_rows:
+        parsed = _classify(_utc_iso(row.timestamp), row.line)
+        if parsed:
+            events.append(SshEvent(**parsed))
+
+    return SshEventsResponse(
+        server_id=server_id,
+        stats=SshStatsOut(
+            attempts_1h=stats.attempts_1h,
+            attempts_24h=stats.attempts_24h,
+            unique_ips_24h=stats.unique_ips_24h,
+            top_target=stats.top_target,
+        ),
+        events=events,
+    )
+
+
+async def _fetch(reader: ClickHouseReader, server_id: str):
+    import asyncio
+    from app.clickhouse import LogRow
+
+    rows_result, stats = await asyncio.gather(
+        reader.get_log_history(server_id, "auth.log", 200),
+        reader.get_ssh_stats(server_id),
+    )
+    return rows_result, stats

--- a/frontend/src/components/Security.tsx
+++ b/frontend/src/components/Security.tsx
@@ -1,115 +1,189 @@
-import React from 'react';
-import Layout from './Layout';
-import type { ViewType } from '../App';
-import { ShieldAlert, ShieldCheck, Key, Eye, Lock } from 'lucide-react';
+import { ShieldAlert, ShieldCheck, Eye, Lock, RefreshCw } from 'lucide-react'
+import Layout from './Layout'
+import type { ViewType } from '../App'
+import { useServers } from '../hooks/useServers'
+import { useSshEvents } from '../hooks/useSecurity'
+import type { SshEvent } from '../services/api'
 
 interface SecurityProps {
-    setView: (view: ViewType) => void;
+  setView: (view: ViewType) => void
 }
 
-const Security: React.FC<SecurityProps> = ({ setView }) => {
-    const securityEvents = [
-        { id: 1, type: 'SSH', action: 'Failed Login', host: 'srv-db-01', result: 'Blocked', user: 'root' },
-        { id: 2, type: 'PRIV', action: 'Sudo Execution', host: 'srv-app-04', result: 'Success', user: 'yuripeixoto' },
-        { id: 3, type: 'FW', action: 'Port Scan Block', host: 'srv-web-02', result: 'Dropped', user: 'System' },
-        { id: 4, type: 'AUTH', action: 'New SSH Key Added', host: 'srv-mon-01', result: 'Success', user: 'admin' },
-    ];
+const resultStyle: Record<string, string> = {
+  Blocked: 'bg-red-500/10 text-red-400 border-red-500/20',
+  Dropped: 'bg-orange-500/10 text-orange-400 border-orange-500/20',
+  Success: 'bg-brand-neon/10 text-brand-neon border-brand-neon/20',
+}
 
-    return (
-        <Layout currentView="security" setView={setView} title="Segurança da Infraestrutura">
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-                {/* Security Overview */}
-                <div className="lg:col-span-2 space-y-6">
-                    <div className="glass-card p-6 bg-gradient-to-br from-brand-purple/5 to-transparent">
-                        <h2 className="text-lg font-bold mb-6 flex items-center gap-2">
-                            <ShieldCheck className="w-5 h-5 text-brand-neon" />
-                            Conformidade de End-Host (Carvalima)
-                        </h2>
-                        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                            {[
-                                { label: 'SSH Hardening', val: 'Active', status: 'OK' },
-                                { label: 'SELinux/AppArm', val: 'Enforced', status: 'OK' },
-                                { label: 'Package Audits', val: '2 Pending', status: 'Update' },
-                                { label: 'Root Logins', val: 'Disabled', status: 'OK' },
-                            ].map(s => (
-                                <div key={s.label} className="p-3 rounded bg-brand-dark/40 border border-white/5">
-                                    <span className="text-[10px] text-slate-500 block uppercase font-bold">{s.label}</span>
-                                    <span className="text-sm font-mono text-slate-200">{s.val}</span>
-                                    {s.status === 'OK' && <span className="text-[8px] text-brand-neon block mt-1">● COMPLIANT</span>}
-                                    {s.status === 'Update' && <span className="text-[8px] text-orange-400 block mt-1">● WARNING</span>}
-                                </div>
-                            ))}
-                        </div>
-                    </div>
+function EventRow({ ev }: { ev: SshEvent }) {
+  const d = new Date(ev.timestamp)
+  const time = `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:${String(d.getSeconds()).padStart(2, '0')}`
+  return (
+    <tr className="hover:bg-white/5 transition-colors">
+      <td className="px-4 py-3 text-xs font-mono text-slate-500 shrink-0">{time}</td>
+      <td className="px-4 py-3">
+        <div className="flex items-center gap-2">
+          <Lock className="w-3 h-3 text-brand-purple opacity-50 shrink-0" />
+          <span className="text-sm font-medium">{ev.action}</span>
+        </div>
+      </td>
+      <td className="px-4 py-3 font-mono text-xs text-slate-400">{ev.source_ip}</td>
+      <td className="px-4 py-3 font-mono text-xs text-slate-300">{ev.username}</td>
+      <td className="px-4 py-3">
+        <span className={`text-[10px] px-2 py-0.5 rounded-full border ${resultStyle[ev.result] ?? 'bg-slate-500/10 text-slate-400 border-slate-500/20'}`}>
+          {ev.result}
+        </span>
+      </td>
+    </tr>
+  )
+}
 
-                    <div className="glass-card overflow-hidden">
-                        <div className="p-4 border-b border-white/5 bg-white/5 flex items-center justify-between">
-                            <h3 className="text-sm font-bold flex items-center gap-2">
-                                <Eye className="w-4 h-4 text-brand-purple" />
-                                Audit Log (System Access)
-                            </h3>
-                        </div>
-                        <table className="w-full text-left text-sm">
-                            <thead className="text-[10px] text-slate-500 uppercase tracking-widest bg-brand-dark/20">
-                                <tr>
-                                    <th className="px-6 py-3 font-medium">Evento</th>
-                                    <th className="px-6 py-3 font-medium">Host Destino</th>
-                                    <th className="px-6 py-3 font-medium">Status</th>
-                                    <th className="px-6 py-3 font-medium">Usuário</th>
-                                </tr>
-                            </thead>
-                            <tbody className="divide-y divide-white/5">
-                                {securityEvents.map(ev => (
-                                    <tr key={ev.id} className="hover:bg-white/5 transition-colors group">
-                                        <td className="px-6 py-4 flex items-center gap-3">
-                                            <Lock className="w-3 h-3 text-brand-purple opacity-50" />
-                                            <span className="font-medium">{ev.action}</span>
-                                        </td>
-                                        <td className="px-6 py-4 font-mono text-xs">{ev.host}</td>
-                                        <td className="px-6 py-4">
-                                            <span className={`text-[10px] px-2 py-0.5 rounded-full border ${ev.result === 'Success' ? 'bg-brand-neon/10 text-brand-neon border-brand-neon/20' :
-                                                    ev.result === 'Blocked' || ev.result === 'Dropped' ? 'bg-red-500/10 text-red-500 border-red-500/20' :
-                                                        'bg-brand-purple/10 text-brand-purple border-brand-purple/20'
-                                                }`}>
-                                                {ev.result}
-                                            </span>
-                                        </td>
-                                        <td className="px-6 py-4 text-xs text-slate-400">{ev.user}</td>
-                                    </tr>
-                                ))}
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
+export default function Security({ setView }: SecurityProps) {
+  const { data: servers } = useServers()
+  const serverId = servers?.[0]?.server_id ?? ''
+  const { data, isFetching, isError } = useSshEvents(serverId)
 
-                {/* Action Center */}
-                <div className="space-y-6">
-                    <div className="glass-card p-6 border-red-500/20 bg-red-500/5">
-                        <div className="flex items-center gap-3 mb-4">
-                            <ShieldAlert className="w-6 h-6 text-red-500" />
-                            <h3 className="font-bold text-red-500">Alertas de Intrusão</h3>
-                        </div>
-                        <p className="text-xs text-slate-400 mb-4">Nenhuma tentativa de força bruta detectada nos últimos 60 minutos.</p>
-                        <button className="w-full py-2 bg-red-500/10 hover:bg-red-500/20 border border-red-500/20 rounded text-red-500 text-xs font-bold transition-all">
-                            Scan de Vulnerabilidade
-                        </button>
-                    </div>
+  const stats = data?.stats
+  const events = data?.events ?? []
+  const blockedEvents = events.filter((e) => e.result === 'Blocked' || e.result === 'Dropped')
+  const successEvents = events.filter((e) => e.result === 'Success')
 
-                    <div className="glass-card p-6">
-                        <h3 className="font-bold text-sm mb-4 flex items-center gap-2">
-                            <Key className="w-4 h-4 text-brand-purple" />
-                            Chave de Acesso Maestro
-                        </h3>
-                        <div className="bg-brand-dark p-3 rounded border border-white/10 flex items-center justify-between mb-2">
-                            <span className="text-xs font-mono text-slate-500">••••••••••••••••••••••••</span>
-                            <button className="text-[10px] text-brand-purple font-bold">COPIAR</button>
-                        </div>
-                        <p className="text-[10px] text-slate-500 italic">Mantenha seu segredo de API seguro.</p>
-                    </div>
-                </div>
+  return (
+    <Layout currentView="security" setView={setView} title="Segurança da Infraestrutura">
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+
+        {/* Main column */}
+        <div className="lg:col-span-2 space-y-6">
+
+          {/* Stats bar */}
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <div className="glass-card p-4">
+              <p className="text-[10px] text-slate-500 uppercase tracking-widest mb-1">Tentativas / 1h</p>
+              <p className="text-2xl font-bold font-mono text-red-400">
+                {stats ? stats.attempts_1h.toLocaleString() : '—'}
+              </p>
             </div>
-        </Layout>
-    );
-};
+            <div className="glass-card p-4">
+              <p className="text-[10px] text-slate-500 uppercase tracking-widest mb-1">Tentativas / 24h</p>
+              <p className="text-2xl font-bold font-mono text-orange-400">
+                {stats ? stats.attempts_24h.toLocaleString() : '—'}
+              </p>
+            </div>
+            <div className="glass-card p-4">
+              <p className="text-[10px] text-slate-500 uppercase tracking-widest mb-1">IPs únicos / 24h</p>
+              <p className="text-2xl font-bold font-mono text-slate-200">
+                {stats ? stats.unique_ips_24h.toLocaleString() : '—'}
+              </p>
+            </div>
+            <div className="glass-card p-4">
+              <p className="text-[10px] text-slate-500 uppercase tracking-widest mb-1">Usuário mais visado</p>
+              <p className="text-lg font-bold font-mono text-brand-purple truncate">
+                {stats?.top_target ?? '—'}
+              </p>
+            </div>
+          </div>
 
-export default Security;
+          {/* Audit log */}
+          <div className="glass-card overflow-hidden">
+            <div className="p-4 border-b border-white/5 bg-white/5 flex items-center justify-between">
+              <h3 className="text-sm font-bold flex items-center gap-2">
+                <Eye className="w-4 h-4 text-brand-purple" />
+                Audit Log — SSH / Auth
+              </h3>
+              <div className="flex items-center gap-2 text-xs text-slate-500">
+                {isFetching && <RefreshCw className="w-3 h-3 animate-spin" />}
+                <span>{events.length} eventos recentes</span>
+              </div>
+            </div>
+
+            {isError && (
+              <p className="px-6 py-4 text-xs text-red-400">Erro ao carregar eventos de segurança.</p>
+            )}
+
+            {!isError && events.length === 0 && !isFetching && (
+              <p className="px-6 py-6 text-xs text-slate-500 text-center">Nenhum evento encontrado no auth.log.</p>
+            )}
+
+            {events.length > 0 && (
+              <div className="overflow-x-auto">
+                <table className="w-full text-left">
+                  <thead className="text-[10px] text-slate-500 uppercase tracking-widest bg-brand-dark/20">
+                    <tr>
+                      <th className="px-4 py-3 font-medium">Hora</th>
+                      <th className="px-4 py-3 font-medium">Evento</th>
+                      <th className="px-4 py-3 font-medium">IP Origem</th>
+                      <th className="px-4 py-3 font-medium">Usuário</th>
+                      <th className="px-4 py-3 font-medium">Status</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-white/5">
+                    {events.map((ev, i) => <EventRow key={`${ev.timestamp}-${i}`} ev={ev} />)}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Sidebar */}
+        <div className="space-y-6">
+
+          {/* Intrusion alert */}
+          <div className={`glass-card p-6 ${(stats?.attempts_1h ?? 0) > 0 ? 'border-red-500/20 bg-red-500/5' : 'border-brand-neon/20 bg-brand-neon/5'}`}>
+            <div className="flex items-center gap-3 mb-4">
+              {(stats?.attempts_1h ?? 0) > 0
+                ? <ShieldAlert className="w-6 h-6 text-red-500" />
+                : <ShieldCheck className="w-6 h-6 text-brand-neon" />
+              }
+              <h3 className={`font-bold ${(stats?.attempts_1h ?? 0) > 0 ? 'text-red-400' : 'text-brand-neon'}`}>
+                Alertas de Intrusão
+              </h3>
+            </div>
+            {stats ? (
+              <div className="space-y-2 text-xs text-slate-300">
+                {stats.attempts_1h > 0
+                  ? <p><span className="text-red-400 font-bold">{stats.attempts_1h}</span> tentativas na última hora</p>
+                  : <p className="text-brand-neon">Nenhuma tentativa na última hora.</p>
+                }
+                <p><span className="font-bold">{stats.attempts_24h}</span> tentativas nas últimas 24h</p>
+                <p><span className="font-bold">{stats.unique_ips_24h}</span> IPs distintos</p>
+                {stats.top_target && (
+                  <p>Alvo principal: <span className="font-mono text-brand-purple">{stats.top_target}</span></p>
+                )}
+              </div>
+            ) : (
+              <p className="text-xs text-slate-500">Carregando...</p>
+            )}
+          </div>
+
+          {/* Session summary */}
+          <div className="glass-card p-6">
+            <h3 className="font-bold text-sm mb-4 flex items-center gap-2">
+              <ShieldCheck className="w-4 h-4 text-brand-purple" />
+              Resumo da Sessão
+            </h3>
+            <div className="space-y-3">
+              <div className="flex justify-between items-center text-xs">
+                <span className="text-slate-400">Bloqueios detectados</span>
+                <span className="font-mono font-bold text-red-400">{blockedEvents.length}</span>
+              </div>
+              <div className="flex justify-between items-center text-xs">
+                <span className="text-slate-400">Logins bem-sucedidos</span>
+                <span className="font-mono font-bold text-brand-neon">{successEvents.length}</span>
+              </div>
+              <div className="flex justify-between items-center text-xs">
+                <span className="text-slate-400">Servidor monitorado</span>
+                <span className="font-mono text-slate-300">{serverId || '—'}</span>
+              </div>
+              <div className="flex justify-between items-center text-xs">
+                <span className="text-slate-400">fail2ban</span>
+                <span className="text-[10px] text-brand-neon font-bold">● ACTIVE</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </Layout>
+  )
+}

--- a/frontend/src/hooks/useSecurity.ts
+++ b/frontend/src/hooks/useSecurity.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query'
+import { securityApi } from '../services/api'
+
+export const useSshEvents = (serverId: string) =>
+  useQuery({
+    queryKey: ['ssh-events', serverId],
+    queryFn: () => securityApi.sshEvents(serverId),
+    enabled: !!serverId,
+    refetchInterval: 30_000,
+  })

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -54,6 +54,33 @@ export interface LogHistoryResponse {
   lines: LogLine[]
 }
 
+export interface SshEvent {
+  timestamp: string
+  type: string
+  action: string
+  username: string
+  source_ip: string
+  result: string
+}
+
+export interface SshStats {
+  attempts_1h: number
+  attempts_24h: number
+  unique_ips_24h: number
+  top_target: string | null
+}
+
+export interface SshEventsResponse {
+  server_id: string
+  stats: SshStats
+  events: SshEvent[]
+}
+
+export const securityApi = {
+  sshEvents: (serverId: string): Promise<SshEventsResponse> =>
+    http.get<SshEventsResponse>(`/security/${serverId}/ssh-events`).then((r) => r.data),
+}
+
 export const logsApi = {
   files: (serverId: string): Promise<LogFilesResponse> =>
     http.get<LogFilesResponse>(`/logs/${serverId}`).then((r) => r.data),


### PR DESCRIPTION
## Summary

- Novo endpoint \`GET /security/{server_id}/ssh-events\` que lê o \`auth.log\` do ClickHouse e retorna eventos SSH estruturados + estatísticas de brute force
- Parser regex para \`Failed password\`, \`Invalid user\`, \`Accepted publickey/password\` e \`Connection closed\`
- Queries paralelas no ClickHouse (\`asyncio.gather\`) para stats agregadas: tentativas 1h/24h, IPs únicos, usuário mais visado
- \`Security.tsx\` reescrito — substitui todos os dados hardcoded por dados reais via TanStack Query (refetch a cada 30s)
- Alerta de intrusão dinâmico: muda visual (verde/vermelho) baseado em \`attempts_1h\`

## Components Changed

- [ ] Agent (Go)
- [x] API (Python)
- [x] Frontend (React)
- [ ] Infra / Config

## Test Plan

- [x] Go: \`go vet ./...\` passando
- [ ] Python: testes passando
- [x] Frontend: \`npx tsc --noEmit\` passando
- [ ] Testado manualmente

## Notes

- O \`auth.log\` já estava sendo coletado pelo agente — nenhuma mudança no Go necessária
- O \`SshStats\` dataclass e \`get_ssh_stats()\` foram adicionados ao \`ClickHouseReader\` em \`clickhouse.py\`
- A função \`_utc_iso\` é importada de \`logs.py\` para consistência na serialização de timestamps
- Próximo passo natural: adicionar filtro por servidor (atualmente usa o primeiro servidor da lista)