### PR TITLE
feat(inventory): runtime versions and service status on Infrastructure view

### DIFF
--- a/agent/cmd/agent/main.go
+++ b/agent/cmd/agent/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/yuriPeixoto/maestro/agent/internal/collector"
 	"github.com/yuriPeixoto/maestro/agent/internal/config"
 	"github.com/yuriPeixoto/maestro/agent/internal/heartbeat"
+	"github.com/yuriPeixoto/maestro/agent/internal/inventory"
 	"github.com/yuriPeixoto/maestro/agent/internal/logwatcher"
 	"github.com/yuriPeixoto/maestro/agent/internal/publisher"
 )
@@ -39,6 +40,11 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	// Inventory — detect installed runtimes and service statuses once at startup.
+	log.Printf("info: collecting runtime inventory...")
+	inv := inventory.Collect(ctx)
+	log.Printf("info: inventory collected — %d entries", len(inv))
+
 	// Log watcher — tails configured files and emits lines to Redis Streams.
 	// Returns the subset of paths that actually exist (passed to heartbeat).
 	watchedLogs := logwatcher.Start(ctx, logwatcher.Config{
@@ -52,13 +58,14 @@ func main() {
 
 	// Heartbeat emitter — runs independently, failures never affect metric collection.
 	if err := heartbeat.Start(ctx, heartbeat.Config{
-		ServerID:      cfg.ServerID,
-		Stream:        cfg.Heartbeat.Stream,
-		Interval:      cfg.Heartbeat.Interval,
-		RedisAddr:     cfg.Redis.Addr,
-		RedisPassword: cfg.Redis.Password,
-		WatchedLogs:   watchedLogs,
-		Debug:         cfg.Debug,
+		ServerID:         cfg.ServerID,
+		Stream:           cfg.Heartbeat.Stream,
+		Interval:         cfg.Heartbeat.Interval,
+		RedisAddr:        cfg.Redis.Addr,
+		RedisPassword:    cfg.Redis.Password,
+		WatchedLogs:      watchedLogs,
+		InitialInventory: inv,
+		Debug:            cfg.Debug,
 	}); err != nil {
 		log.Printf("warn: heartbeat emitter failed to start: %v — continuing without heartbeat", err)
 	}

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/redis/go-redis/v9"
+	"github.com/yuriPeixoto/maestro/agent/internal/inventory"
 )
 
 // Version is the current agent version, injected at build time via -ldflags.
@@ -16,21 +17,23 @@ var Version = "dev"
 
 // Payload is the heartbeat message emitted to Redis Streams.
 type Payload struct {
-	ServerID     string    `json:"server_id"`
-	Timestamp    time.Time `json:"timestamp"`
-	AgentVersion string    `json:"agent_version"`
-	WatchedLogs  []string  `json:"watched_logs,omitempty"`
+	ServerID     string            `json:"server_id"`
+	Timestamp    time.Time         `json:"timestamp"`
+	AgentVersion string            `json:"agent_version"`
+	WatchedLogs  []string          `json:"watched_logs,omitempty"`
+	Inventory    []inventory.Entry `json:"inventory,omitempty"`
 }
 
 // Config holds all parameters needed by the emitter.
 type Config struct {
-	ServerID      string
-	Stream        string
-	Interval      time.Duration
-	RedisAddr     string
-	RedisPassword string
-	WatchedLogs   []string
-	Debug         bool
+	ServerID         string
+	Stream           string
+	Interval         time.Duration
+	RedisAddr        string
+	RedisPassword    string
+	WatchedLogs      []string
+	InitialInventory []inventory.Entry
+	Debug            bool
 }
 
 // Start launches the heartbeat emitter as a goroutine.
@@ -66,15 +69,18 @@ func Start(ctx context.Context, cfg Config) error {
 		ticker := time.NewTicker(cfg.Interval)
 		defer ticker.Stop()
 
+		cachedInventory := cfg.InitialInventory
+
 		// Emit immediately on startup so the server is visible right away.
-		emit(ctx, cfg, client)
+		emit(ctx, cfg, client, cachedInventory)
 
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				emit(ctx, cfg, client)
+				cachedInventory = inventory.RefreshStatus(ctx, cachedInventory)
+				emit(ctx, cfg, client, cachedInventory)
 			}
 		}
 	}()
@@ -82,12 +88,13 @@ func Start(ctx context.Context, cfg Config) error {
 	return nil
 }
 
-func emit(ctx context.Context, cfg Config, client *redis.Client) {
+func emit(ctx context.Context, cfg Config, client *redis.Client, inv []inventory.Entry) {
 	p := Payload{
 		ServerID:     cfg.ServerID,
 		Timestamp:    time.Now().UTC(),
 		AgentVersion: Version,
 		WatchedLogs:  cfg.WatchedLogs,
+		Inventory:    inv,
 	}
 
 	payload, err := json.Marshal(p)

--- a/agent/internal/inventory/inventory.go
+++ b/agent/internal/inventory/inventory.go
@@ -1,0 +1,173 @@
+package inventory
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Entry describes a single runtime or service detected on the host.
+type Entry struct {
+	Name        string     `json:"name"`
+	Version     string     `json:"version"`
+	Status      string     `json:"status"`       // "active" | "inactive" | "failed" | "unknown" | "n/a"
+	UptimeSince *time.Time `json:"uptime_since"` // nil for non-daemon runtimes
+}
+
+type descriptor struct {
+	name        string
+	versionArgs []string
+	versionRe   *regexp.Regexp
+	service     string // systemd unit name; empty = no daemon
+}
+
+var runtimes = []descriptor{
+	{"Go", []string{"go", "version"}, regexp.MustCompile(`go(\d+\.\d+(?:\.\d+)?)`), ""},
+	{"Python", []string{"python3", "--version"}, regexp.MustCompile(`Python (\S+)`), ""},
+	{"Node.js", []string{"node", "--version"}, regexp.MustCompile(`v(\S+)`), ""},
+	{"PHP", []string{"php", "--version"}, regexp.MustCompile(`PHP (\d+\.\d+\.\d+)`), ""},
+	{"Composer", []string{"composer", "--version", "--no-ansi"}, regexp.MustCompile(`Composer version (\S+)`), ""},
+	{"PostgreSQL", []string{"psql", "--version"}, regexp.MustCompile(`(\d+\.\d+(?:\.\d+)?)`), "postgresql"},
+	{"ClickHouse", []string{"clickhouse-client", "--version"}, regexp.MustCompile(`(\d+\.\d+\.\d+\.\d+)`), "clickhouse-server"},
+	{"Redis", []string{"redis-cli", "--version"}, regexp.MustCompile(`redis-cli (\S+)`), "redis"},
+	{"Nginx", []string{"nginx", "-v"}, regexp.MustCompile(`nginx/(\S+)`), "nginx"},
+}
+
+// Collect detects installed runtimes and their service statuses concurrently.
+// Safe to call once at agent startup; results should be cached and refreshed
+// via RefreshStatus on subsequent heartbeats.
+func Collect(ctx context.Context) []Entry {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	entries := make([]Entry, len(runtimes)+1) // +1 for OS
+	entries[0] = osEntry()
+
+	var wg sync.WaitGroup
+	for i, rt := range runtimes {
+		wg.Add(1)
+		go func(idx int, d descriptor) {
+			defer wg.Done()
+			entries[idx+1] = detect(ctx, d)
+		}(i, rt)
+	}
+	wg.Wait()
+
+	return entries
+}
+
+// RefreshStatus re-checks systemd service status for daemon entries,
+// preserving the version strings from the original Collect call.
+func RefreshStatus(ctx context.Context, entries []Entry) []Entry {
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	// Build a service→index map to avoid O(n²) lookup.
+	serviceIdx := make(map[string]int, len(entries))
+	for i, e := range entries {
+		if e.Name == "OS" {
+			continue
+		}
+		for _, d := range runtimes {
+			if d.name == e.Name && d.service != "" {
+				serviceIdx[d.service] = i
+			}
+		}
+	}
+
+	refreshed := make([]Entry, len(entries))
+	copy(refreshed, entries)
+
+	var wg sync.WaitGroup
+	for svc, idx := range serviceIdx {
+		wg.Add(1)
+		go func(service string, i int) {
+			defer wg.Done()
+			status, since := serviceStatus(ctx, service)
+			refreshed[i].Status = status
+			refreshed[i].UptimeSince = since
+		}(svc, idx)
+	}
+	wg.Wait()
+
+	return refreshed
+}
+
+func osEntry() Entry {
+	version := osVersion()
+	return Entry{Name: "OS", Version: version, Status: "n/a"}
+}
+
+func osVersion() string {
+	f, err := os.Open("/etc/os-release")
+	if err != nil {
+		return "unknown"
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "PRETTY_NAME=") {
+			val := strings.TrimPrefix(line, "PRETTY_NAME=")
+			return strings.Trim(val, `"`)
+		}
+	}
+	return "unknown"
+}
+
+func detect(ctx context.Context, d descriptor) Entry {
+	e := Entry{Name: d.name, Version: "not found", Status: "n/a"}
+
+	out, _ := exec.CommandContext(ctx, d.versionArgs[0], d.versionArgs[1:]...).CombinedOutput()
+	if m := d.versionRe.FindSubmatch(out); len(m) > 1 {
+		e.Version = string(m[1])
+	} else {
+		return e
+	}
+
+	if d.service != "" {
+		e.Status, e.UptimeSince = serviceStatus(ctx, d.service)
+	}
+	return e
+}
+
+func serviceStatus(ctx context.Context, service string) (string, *time.Time) {
+	out, err := exec.CommandContext(ctx, "systemctl", "is-active", service).Output()
+	status := strings.TrimSpace(string(out))
+	if err != nil || status == "" {
+		status = "inactive"
+	}
+
+	if status != "active" {
+		return status, nil
+	}
+
+	tsOut, err := exec.CommandContext(ctx, "systemctl", "show", service,
+		"--property=ActiveEnterTimestamp", "--value").Output()
+	if err != nil {
+		return status, nil
+	}
+
+	raw := strings.TrimSpace(string(tsOut))
+	if raw == "" || raw == "n/a" {
+		return status, nil
+	}
+
+	// systemd format: "Mon 2026-05-18 14:30:00 -0400"
+	for _, layout := range []string{
+		"Mon 2006-01-02 15:04:05 -0700",
+		"Mon 2006-01-02 15:04:05 MST",
+	} {
+		if t, err := time.Parse(layout, raw); err == nil {
+			utc := t.UTC()
+			return status, &utc
+		}
+	}
+	return status, nil
+}

--- a/api/app/heartbeat.py
+++ b/api/app/heartbeat.py
@@ -25,6 +25,7 @@ def _parse_heartbeat(raw: str) -> dict | None:
             "last_seen": last_seen.isoformat(),
             "agent_version": data.get("agent_version", "unknown"),
             "watched_logs": data.get("watched_logs") or [],
+            "inventory": data.get("inventory") or [],
         }
     except Exception as exc:
         logger.warning("heartbeat: failed to parse payload: %s — raw: %.200s", exc, raw)
@@ -66,6 +67,7 @@ async def run_heartbeat_consumer() -> None:
                             "last_seen": parsed["last_seen"],
                             "agent_version": parsed["agent_version"],
                             "watched_logs": parsed["watched_logs"],
+                            "inventory": parsed["inventory"],
                         }),
                     )
                     logger.debug("heartbeat: updated '%s' last_seen=%s", parsed["server_id"], parsed["last_seen"])

--- a/api/app/inventory.py
+++ b/api/app/inventory.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+
+import redis.asyncio as aioredis
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from app.config import settings
+from app.servers import get_redis
+
+router = APIRouter(prefix="/inventory", tags=["inventory"])
+
+
+class RuntimeEntry(BaseModel):
+    name: str
+    version: str
+    status: str
+    uptime_since: str | None = None
+
+
+class InventoryResponse(BaseModel):
+    server_id: str
+    inventory: list[RuntimeEntry]
+
+
+@router.get("/{server_id}", response_model=InventoryResponse)
+async def get_inventory(server_id: str, redis: aioredis.Redis = Depends(get_redis)) -> InventoryResponse:
+    raw: str | None = await redis.hget(settings.heartbeat_state_key, server_id)
+    if raw is None:
+        raise HTTPException(status_code=404, detail=f"Server '{server_id}' not found")
+
+    data = json.loads(raw)
+    entries = [RuntimeEntry(**e) for e in data.get("inventory") or []]
+    return InventoryResponse(server_id=server_id, inventory=entries)

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -10,6 +10,7 @@ from app.clickhouse import ClickHouseReader, ClickHouseWriter
 from app.consumer import run_consumer
 from app.heartbeat import run_heartbeat_consumer
 from app.log_consumer import run_log_consumer
+from app.inventory import router as inventory_router
 from app.logs import router as logs_router
 from app.metrics import router as metrics_router
 from app.security import router as security_router
@@ -61,6 +62,7 @@ app.include_router(servers_router, dependencies=_protected)
 app.include_router(metrics_router, dependencies=_protected)
 app.include_router(logs_router, dependencies=_protected)
 app.include_router(security_router, dependencies=_protected)
+app.include_router(inventory_router, dependencies=_protected)
 
 
 @app.get("/")

--- a/frontend/src/components/Infrastructure.tsx
+++ b/frontend/src/components/Infrastructure.tsx
@@ -1,10 +1,11 @@
-import React from 'react'
-import { Server, Network, Clock } from 'lucide-react'
+import { Server, Network, Clock, Package, CheckCircle, XCircle, HelpCircle, RefreshCw } from 'lucide-react'
 import Layout from './Layout'
 import type { ViewType } from '../App'
 import { useServers } from '../hooks/useServers'
 import { useUIStore } from '../store/uiStore'
+import { useInventory } from '../hooks/useInventory'
 import type { ServerStatus } from '../types/server'
+import type { RuntimeEntry } from '../services/api'
 
 interface InfrastructureProps {
   setView: (view: ViewType) => void
@@ -30,12 +31,134 @@ function timeAgo(iso: string | null): string {
   return `${Math.floor(diff / 3600)}h atrás`
 }
 
-const Infrastructure: React.FC<InfrastructureProps> = ({ setView }) => {
+function uptimeSince(iso: string | null): string {
+  if (!iso) return '—'
+  const diff = Math.floor((Date.now() - new Date(iso).getTime()) / 1000)
+  if (diff < 3600) return `${Math.floor(diff / 60)}m`
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h`
+  return `${Math.floor(diff / 86400)}d`
+}
+
+function ServiceStatus({ status }: { status: string }) {
+  if (status === 'active')
+    return <CheckCircle className="w-3.5 h-3.5 text-brand-neon" />
+  if (status === 'inactive' || status === 'failed')
+    return <XCircle className="w-3.5 h-3.5 text-red-400" />
+  return <HelpCircle className="w-3.5 h-3.5 text-slate-500" />
+}
+
+function InventoryTable({ serverId }: { serverId: string }) {
+  const { data, isFetching, isError } = useInventory(serverId)
+
+  if (isError) return <p className="text-xs text-red-400 mt-4">Erro ao carregar inventário.</p>
+  if (!data) return <p className="text-xs text-slate-500 mt-4">Carregando inventário...</p>
+
+  const daemons = data.inventory.filter((e) => e.status !== 'n/a' && e.status !== 'unknown')
+  const runtimes = data.inventory.filter((e) => e.status === 'n/a' || e.status === 'unknown')
+
+  return (
+    <div className="mt-6 space-y-6">
+      {daemons.length > 0 && (
+        <div className="glass-card overflow-hidden">
+          <div className="px-4 py-3 border-b border-white/5 bg-white/5 flex items-center justify-between">
+            <h3 className="text-xs font-bold uppercase tracking-widest text-slate-400 flex items-center gap-2">
+              <Server className="w-3.5 h-3.5 text-brand-purple" />
+              Serviços
+            </h3>
+            {isFetching && <RefreshCw className="w-3 h-3 animate-spin text-slate-500" />}
+          </div>
+          <table className="w-full text-left">
+            <thead className="text-[10px] text-slate-500 uppercase tracking-widest bg-brand-dark/20">
+              <tr>
+                <th className="px-4 py-2 font-medium">Serviço</th>
+                <th className="px-4 py-2 font-medium">Versão</th>
+                <th className="px-4 py-2 font-medium">Status</th>
+                <th className="px-4 py-2 font-medium">Uptime</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-white/5">
+              {daemons.map((e) => (
+                <ServiceRow key={e.name} entry={e} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {runtimes.length > 0 && (
+        <div className="glass-card overflow-hidden">
+          <div className="px-4 py-3 border-b border-white/5 bg-white/5">
+            <h3 className="text-xs font-bold uppercase tracking-widest text-slate-400 flex items-center gap-2">
+              <Package className="w-3.5 h-3.5 text-brand-purple" />
+              Runtimes
+            </h3>
+          </div>
+          <table className="w-full text-left">
+            <thead className="text-[10px] text-slate-500 uppercase tracking-widest bg-brand-dark/20">
+              <tr>
+                <th className="px-4 py-2 font-medium">Runtime</th>
+                <th className="px-4 py-2 font-medium">Versão</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-white/5">
+              {runtimes.map((e) => (
+                <tr key={e.name} className="hover:bg-white/5 transition-colors">
+                  <td className="px-4 py-2.5 text-sm font-medium text-slate-200">{e.name}</td>
+                  <td className="px-4 py-2.5 font-mono text-xs text-slate-400">
+                    {e.version === 'not found'
+                      ? <span className="text-slate-600">não instalado</span>
+                      : e.version}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ServiceRow({ entry: e }: { entry: RuntimeEntry }) {
+  return (
+    <tr className="hover:bg-white/5 transition-colors">
+      <td className="px-4 py-2.5 text-sm font-medium text-slate-200">{e.name}</td>
+      <td className="px-4 py-2.5 font-mono text-xs text-slate-400">
+        {e.version === 'not found'
+          ? <span className="text-slate-600">não instalado</span>
+          : e.version}
+      </td>
+      <td className="px-4 py-2.5">
+        <div className="flex items-center gap-1.5">
+          <ServiceStatus status={e.status} />
+          <span className={`text-xs ${
+            e.status === 'active' ? 'text-brand-neon'
+            : e.status === 'failed' ? 'text-red-400'
+            : 'text-slate-500'
+          }`}>
+            {e.status}
+          </span>
+        </div>
+      </td>
+      <td className="px-4 py-2.5 font-mono text-xs text-slate-500">
+        {uptimeSince(e.uptime_since)}
+      </td>
+    </tr>
+  )
+}
+
+export default function Infrastructure({ setView }: InfrastructureProps) {
   const { data: servers, isLoading, isError } = useServers()
+  const selectedAgentId = useUIStore((s) => s.selectedAgentId)
   const setSelectedAgentId = useUIStore((s) => s.setSelectedAgentId)
 
-  const handleSelect = (serverId: string) => {
-    setSelectedAgentId(serverId)
+  const serverId = selectedAgentId
+    ?? servers?.find((s) => s.status === 'online')?.server_id
+    ?? servers?.[0]?.server_id
+    ?? ''
+
+  const handleSelect = (id: string) => {
+    setSelectedAgentId(id)
     setView('server')
   }
 
@@ -51,12 +174,8 @@ const Infrastructure: React.FC<InfrastructureProps> = ({ setView }) => {
         </p>
       </div>
 
-      {isLoading && (
-        <p className="text-slate-400 text-sm">Carregando servidores...</p>
-      )}
-      {isError && (
-        <p className="text-red-400 text-sm">Erro ao carregar servidores.</p>
-      )}
+      {isLoading && <p className="text-slate-400 text-sm">Carregando servidores...</p>}
+      {isError && <p className="text-red-400 text-sm">Erro ao carregar servidores.</p>}
 
       {servers && servers.length === 0 && (
         <div className="glass-card p-10 text-center">
@@ -104,8 +223,8 @@ const Infrastructure: React.FC<InfrastructureProps> = ({ setView }) => {
           </button>
         ))}
       </div>
+
+      {serverId && <InventoryTable serverId={serverId} />}
     </Layout>
   )
 }
-
-export default Infrastructure

--- a/frontend/src/hooks/useInventory.ts
+++ b/frontend/src/hooks/useInventory.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query'
+import { inventoryApi } from '../services/api'
+
+export const useInventory = (serverId: string) =>
+  useQuery({
+    queryKey: ['inventory', serverId],
+    queryFn: () => inventoryApi.get(serverId),
+    enabled: !!serverId,
+    staleTime: 5 * 60_000,
+    refetchInterval: 30_000,
+  })

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -69,6 +69,18 @@ export interface LogHistoryResponse {
   lines: LogLine[]
 }
 
+export interface RuntimeEntry {
+  name: string
+  version: string
+  status: string
+  uptime_since: string | null
+}
+
+export interface InventoryResponse {
+  server_id: string
+  inventory: RuntimeEntry[]
+}
+
 export interface SshEvent {
   timestamp: string
   type: string
@@ -94,6 +106,11 @@ export interface SshEventsResponse {
 export const securityApi = {
   sshEvents: (serverId: string): Promise<SshEventsResponse> =>
     http.get<SshEventsResponse>(`/security/${serverId}/ssh-events`).then((r) => r.data),
+}
+
+export const inventoryApi = {
+  get: (serverId: string): Promise<InventoryResponse> =>
+    http.get<InventoryResponse>(`/inventory/${serverId}`).then((r) => r.data),
 }
 
 export const logsApi = {


### PR DESCRIPTION
## Summary

- New `internal/inventory` Go package detects installed runtimes and service statuses concurrently (goroutines, 5s timeout): OS, Go, Python, Node.js, PHP, Composer, PostgreSQL, ClickHouse, Redis, Nginx
- Versions collected once at agent startup and cached in memory; service statuses (via `systemctl is-active` + `ActiveEnterTimestamp`) refreshed on every heartbeat tick (30s)
- Heartbeat payload extended with `inventory` field; heartbeat consumer persists it alongside existing state in `maestro:server_heartbeats` Redis hash
- New `GET /inventory/{server_id}` API endpoint reads from Redis hash
- Infrastructure view rewritten with real data: two tables — **Serviços** (status + uptime) and **Runtimes** (installed versions)

## Components Changed

- [x] Agent (Go)
- [x] API (Python)
- [x] Frontend (React)
- [ ] Infra / Config

## Test Plan

- [x] Go: `go test ./...` passando
- [ ] Python: testes passando
- [x] Frontend: `npx tsc --noEmit` passando
- [ ] Testado manualmente no servidor

## Notes

- Runtimes without a systemd service (Go, Python, Node.js, PHP, Composer) show `status: n/a` — only version matters for them
- Service uptime derived from `ActiveEnterTimestamp`; useful for spotting unexpected recent restarts (e.g. the Redis OOM event that triggered this sprint)
- Version data is stable between agent restarts — no need to poll version commands on each heartbeat
- Natural next step: flag runtimes with known CVEs via OSV.dev API

Closes #49