### PR TITLE
feat(alerts): static threshold alerting engine with state machine

### DIFF
--- a/api/app/alert_evaluator.py
+++ b/api/app/alert_evaluator.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import operator as op
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import redis.asyncio as aioredis
+
+from app.clickhouse import AlertEvent, AlertRule, ClickHouseReader, ClickHouseWriter
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+_EVAL_INTERVAL = 30  # seconds
+
+_OPERATORS: dict[str, any] = {
+    ">":  op.gt,
+    "<":  op.lt,
+    ">=": op.ge,
+    "<=": op.le,
+    "==": op.eq,
+}
+
+
+async def run_alert_evaluator(reader: ClickHouseReader, writer: ClickHouseWriter) -> None:
+    redis = aioredis.from_url(settings.redis_url, decode_responses=True)
+    try:
+        logger.info("alert_evaluator: started (interval=%ds)", _EVAL_INTERVAL)
+        while True:
+            await asyncio.sleep(_EVAL_INTERVAL)
+            try:
+                await _evaluate_all(reader, writer, redis)
+            except Exception as exc:
+                logger.error("alert_evaluator: evaluation cycle failed: %s", exc)
+    except asyncio.CancelledError:
+        logger.info("alert_evaluator: shutting down")
+    finally:
+        await redis.aclose()
+
+
+async def _evaluate_all(reader: ClickHouseReader, writer: ClickHouseWriter, redis: aioredis.Redis) -> None:
+    server_ids: list[str] = await redis.hkeys(settings.heartbeat_state_key)
+    for server_id in server_ids:
+        rules = await reader.get_alert_rules(server_id)
+        for rule in rules:
+            try:
+                await _evaluate_rule(rule, reader, writer, redis)
+            except Exception as exc:
+                logger.error("alert_evaluator: rule %s failed: %s", rule.rule_id, exc)
+
+
+async def _evaluate_rule(
+    rule: AlertRule,
+    reader: ClickHouseReader,
+    writer: ClickHouseWriter,
+    redis: aioredis.Redis,
+) -> None:
+    value = await reader.get_latest_metric_value(rule.server_id, rule.metric_name)
+    if value is None:
+        return
+
+    compare = _OPERATORS.get(rule.operator)
+    if compare is None:
+        logger.warning("alert_evaluator: unknown operator %r in rule %s", rule.operator, rule.rule_id)
+        return
+
+    breached = compare(value, rule.threshold)
+    state_key = f"maestro:alert_state:{rule.server_id}:{rule.rule_id}"
+    raw = await redis.get(state_key)
+    current: dict = json.loads(raw) if raw else {
+        "state": "INACTIVE",
+        "last_fired_at": None,
+        "last_resolved_at": None,
+    }
+
+    now = datetime.now(timezone.utc)
+
+    if breached and current["state"] != "FIRING":
+        # Cooldown check: don't re-fire if still within cooldown after last resolution.
+        if current["last_resolved_at"]:
+            last_resolved = datetime.fromisoformat(current["last_resolved_at"])
+            elapsed_minutes = (now - last_resolved).total_seconds() / 60
+            if elapsed_minutes < rule.cooldown_minutes:
+                return
+
+        await writer.insert_alert_event(AlertEvent(
+            event_id=uuid4(), rule_id=rule.rule_id, server_id=rule.server_id,
+            metric_name=rule.metric_name, value=value, threshold=rule.threshold,
+            severity=rule.severity, state="FIRING", triggered_at=now,
+        ))
+        await redis.set(state_key, json.dumps({
+            "state": "FIRING",
+            "last_fired_at": now.isoformat(),
+            "last_resolved_at": current["last_resolved_at"],
+        }))
+        logger.info(
+            "alert: FIRING rule=%s server=%s metric=%s value=%.2f %s %.2f",
+            rule.rule_id, rule.server_id, rule.metric_name, value, rule.operator, rule.threshold,
+        )
+
+    elif not breached and current["state"] == "FIRING":
+        await writer.insert_alert_event(AlertEvent(
+            event_id=uuid4(), rule_id=rule.rule_id, server_id=rule.server_id,
+            metric_name=rule.metric_name, value=value, threshold=rule.threshold,
+            severity=rule.severity, state="RESOLVED", triggered_at=now,
+        ))
+        await redis.set(state_key, json.dumps({
+            "state": "RESOLVED",
+            "last_fired_at": current["last_fired_at"],
+            "last_resolved_at": now.isoformat(),
+        }))
+        logger.info(
+            "alert: RESOLVED rule=%s server=%s metric=%s value=%.2f",
+            rule.rule_id, rule.server_id, rule.metric_name, value,
+        )

--- a/api/app/alerts.py
+++ b/api/app/alerts.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from app.clickhouse import AlertRule, ClickHouseReader
+from app.logs import _utc_iso
+
+router = APIRouter(prefix="/alerts", tags=["alerts"])
+
+
+# ── Request / Response models ─────────────────────────────────────────────────
+
+class AlertRuleIn(BaseModel):
+    metric_name: str
+    operator: str = Field(pattern=r"^(>|<|>=|<=|==)$")
+    threshold: float
+    severity: str = Field(pattern=r"^(warning|critical)$")
+    cooldown_minutes: int = Field(default=5, ge=1, le=1440)
+
+
+class AlertRuleOut(BaseModel):
+    rule_id: str
+    server_id: str
+    metric_name: str
+    operator: str
+    threshold: float
+    severity: str
+    cooldown_minutes: int
+    created_at: str
+
+
+class AlertEventOut(BaseModel):
+    event_id: str
+    rule_id: str
+    metric_name: str
+    value: float
+    threshold: float
+    severity: str
+    state: str
+    triggered_at: str
+
+
+class AlertsResponse(BaseModel):
+    server_id: str
+    events: list[AlertEventOut]
+
+
+class RulesResponse(BaseModel):
+    server_id: str
+    rules: list[AlertRuleOut]
+
+
+# ── Routes ────────────────────────────────────────────────────────────────────
+
+@router.get("/{server_id}/events", response_model=AlertsResponse)
+async def get_alert_events(server_id: str, request: Request, limit: int = 100) -> AlertsResponse:
+    reader: ClickHouseReader = request.app.state.ch_reader
+    events = await reader.get_alert_events(server_id, limit=limit)
+    return AlertsResponse(
+        server_id=server_id,
+        events=[
+            AlertEventOut(
+                event_id=str(e.event_id),
+                rule_id=str(e.rule_id),
+                metric_name=e.metric_name,
+                value=e.value,
+                threshold=e.threshold,
+                severity=e.severity,
+                state=e.state,
+                triggered_at=_utc_iso(e.triggered_at),
+            )
+            for e in events
+        ],
+    )
+
+
+@router.get("/{server_id}/rules", response_model=RulesResponse)
+async def get_alert_rules(server_id: str, request: Request) -> RulesResponse:
+    reader: ClickHouseReader = request.app.state.ch_reader
+    rules = await reader.get_alert_rules(server_id)
+    return RulesResponse(
+        server_id=server_id,
+        rules=[_rule_out(r) for r in rules],
+    )
+
+
+@router.post("/{server_id}/rules", response_model=AlertRuleOut, status_code=201)
+async def create_alert_rule(server_id: str, body: AlertRuleIn, request: Request) -> AlertRuleOut:
+    from app.clickhouse import ClickHouseWriter
+    writer: ClickHouseWriter = request.app.state.ch_writer
+    now = datetime.now(timezone.utc)
+    rule = AlertRule(
+        rule_id=uuid4(),
+        server_id=server_id,
+        metric_name=body.metric_name,
+        operator=body.operator,
+        threshold=body.threshold,
+        severity=body.severity,
+        cooldown_minutes=body.cooldown_minutes,
+        enabled=True,
+        created_at=now,
+    )
+    await writer.insert_alert_rule(rule)
+    return _rule_out(rule)
+
+
+@router.delete("/{server_id}/rules/{rule_id}", status_code=204)
+async def delete_alert_rule(server_id: str, rule_id: str, request: Request) -> None:
+    from app.clickhouse import AlertRule, ClickHouseWriter
+    writer: ClickHouseWriter = request.app.state.ch_writer
+    reader: ClickHouseReader = request.app.state.ch_reader
+
+    rules = await reader.get_alert_rules(server_id)
+    target = next((r for r in rules if str(r.rule_id) == rule_id), None)
+    if target is None:
+        raise HTTPException(status_code=404, detail="Rule not found")
+
+    # Soft-delete via ReplacingMergeTree: insert disabled version with higher version number.
+    disabled = AlertRule(
+        rule_id=target.rule_id, server_id=target.server_id,
+        metric_name=target.metric_name, operator=target.operator,
+        threshold=target.threshold, severity=target.severity,
+        cooldown_minutes=target.cooldown_minutes, enabled=False,
+        created_at=target.created_at,
+    )
+    await writer.insert_alert_rule(disabled)
+
+
+def _rule_out(r: AlertRule) -> AlertRuleOut:
+    return AlertRuleOut(
+        rule_id=str(r.rule_id),
+        server_id=r.server_id,
+        metric_name=r.metric_name,
+        operator=r.operator,
+        threshold=r.threshold,
+        severity=r.severity,
+        cooldown_minutes=r.cooldown_minutes,
+        created_at=_utc_iso(r.created_at),
+    )

--- a/api/app/clickhouse.py
+++ b/api/app/clickhouse.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 from dataclasses import dataclass
 from datetime import datetime
+from uuid import UUID
 
 import clickhouse_connect
 
@@ -13,6 +14,10 @@ logger = logging.getLogger(__name__)
 
 _INSERT_COLUMNS = ["server_id", "metric_name", "value", "timestamp", "tags"]
 _LOG_INSERT_COLUMNS = ["server_id", "log_file", "timestamp", "line"]
+_RULE_INSERT_COLUMNS = ["rule_id", "server_id", "metric_name", "operator", "threshold",
+                        "severity", "cooldown_minutes", "enabled", "created_at", "version"]
+_EVENT_INSERT_COLUMNS = ["event_id", "rule_id", "server_id", "metric_name",
+                         "value", "threshold", "severity", "state", "triggered_at"]
 
 
 @dataclass
@@ -36,6 +41,32 @@ class LogRow:
     log_file: str
     timestamp: datetime
     line: str
+
+
+@dataclass
+class AlertRule:
+    rule_id: UUID
+    server_id: str
+    metric_name: str
+    operator: str
+    threshold: float
+    severity: str
+    cooldown_minutes: int
+    enabled: bool
+    created_at: datetime
+
+
+@dataclass
+class AlertEvent:
+    event_id: UUID
+    rule_id: UUID
+    server_id: str
+    metric_name: str
+    value: float
+    threshold: float
+    severity: str
+    state: str
+    triggered_at: datetime
 
 
 @dataclass
@@ -113,6 +144,23 @@ class ClickHouseWriter:
                 )
                 await asyncio.sleep(delay)
                 delay *= 2
+
+    async def insert_alert_rule(self, rule: AlertRule) -> None:
+        import time as _time
+        data = [[
+            rule.rule_id, rule.server_id, rule.metric_name, rule.operator,
+            rule.threshold, rule.severity, rule.cooldown_minutes,
+            int(rule.enabled), rule.created_at,
+            int(_time.time() * 1000),
+        ]]
+        await self._client.insert("alert_rules", data=data, column_names=_RULE_INSERT_COLUMNS)
+
+    async def insert_alert_event(self, event: AlertEvent) -> None:
+        data = [[
+            event.event_id, event.rule_id, event.server_id, event.metric_name,
+            event.value, event.threshold, event.severity, event.state, event.triggered_at,
+        ]]
+        await self._client.insert("alert_events", data=data, column_names=_EVENT_INSERT_COLUMNS)
 
     async def close(self) -> None:
         if self._client is not None:
@@ -244,6 +292,54 @@ class ClickHouseReader:
             unique_ips_24h=q_ips.result_rows[0][0] if q_ips.result_rows else 0,
             top_target=q_top.result_rows[0][0] if q_top.result_rows else None,
         )
+
+    async def get_alert_rules(self, server_id: str) -> list[AlertRule]:
+        result = await self._client.query(
+            "SELECT rule_id, server_id, metric_name, operator, threshold,"
+            "       severity, cooldown_minutes, enabled, created_at"
+            " FROM alert_rules FINAL"
+            " WHERE server_id = {server_id:String} AND enabled = 1"
+            " ORDER BY created_at",
+            parameters={"server_id": server_id},
+        )
+        return [
+            AlertRule(
+                rule_id=r[0], server_id=r[1], metric_name=r[2], operator=r[3],
+                threshold=r[4], severity=r[5], cooldown_minutes=r[6],
+                enabled=bool(r[7]), created_at=r[8],
+            )
+            for r in result.result_rows
+        ]
+
+    async def get_alert_events(self, server_id: str, limit: int = 100) -> list[AlertEvent]:
+        result = await self._client.query(
+            "SELECT event_id, rule_id, server_id, metric_name, value, threshold,"
+            "       severity, state, triggered_at"
+            " FROM alert_events"
+            " WHERE server_id = {server_id:String}"
+            " ORDER BY triggered_at DESC"
+            " LIMIT {limit:UInt32}",
+            parameters={"server_id": server_id, "limit": limit},
+        )
+        return [
+            AlertEvent(
+                event_id=r[0], rule_id=r[1], server_id=r[2], metric_name=r[3],
+                value=r[4], threshold=r[5], severity=r[6], state=r[7], triggered_at=r[8],
+            )
+            for r in result.result_rows
+        ]
+
+    async def get_latest_metric_value(self, server_id: str, metric_name: str) -> float | None:
+        result = await self._client.query(
+            "SELECT MAX(value) FROM metrics"
+            " WHERE server_id = {server_id:String}"
+            "   AND metric_name = {metric_name:String}"
+            "   AND timestamp >= now() - INTERVAL 5 MINUTE",
+            parameters={"server_id": server_id, "metric_name": metric_name},
+        )
+        if not result.result_rows or result.result_rows[0][0] is None:
+            return None
+        return float(result.result_rows[0][0])
 
     async def close(self) -> None:
         if self._client is not None:

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -4,6 +4,8 @@ from contextlib import asynccontextmanager
 
 from fastapi import Depends, FastAPI
 
+from app.alert_evaluator import run_alert_evaluator
+from app.alerts import router as alerts_router
 from app.auth import get_current_user
 from app.auth import router as auth_router
 from app.clickhouse import ClickHouseReader, ClickHouseWriter
@@ -31,17 +33,19 @@ async def lifespan(app: FastAPI):
     await writer.connect()
     await reader.connect()
     app.state.ch_reader = reader
+    app.state.ch_writer = writer
 
     # Start background consumers.
     metrics_task = asyncio.create_task(run_consumer(writer), name="metrics-consumer")
     heartbeat_task = asyncio.create_task(run_heartbeat_consumer(), name="heartbeat-consumer")
     log_task = asyncio.create_task(run_log_consumer(writer), name="log-consumer")
-    logger.info("app: metrics, heartbeat and log consumers started")
+    alert_task = asyncio.create_task(run_alert_evaluator(reader, writer), name="alert-evaluator")
+    logger.info("app: metrics, heartbeat, log consumers and alert evaluator started")
 
     yield
 
     # Graceful shutdown.
-    for task in (metrics_task, heartbeat_task, log_task):
+    for task in (metrics_task, heartbeat_task, log_task, alert_task):
         task.cancel()
         try:
             await task
@@ -63,6 +67,7 @@ app.include_router(metrics_router, dependencies=_protected)
 app.include_router(logs_router, dependencies=_protected)
 app.include_router(security_router, dependencies=_protected)
 app.include_router(inventory_router, dependencies=_protected)
+app.include_router(alerts_router, dependencies=_protected)
 
 
 @app.get("/")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,7 +5,6 @@ import LogsExplorer from './components/LogsExplorer'
 import Infrastructure from './components/Infrastructure'
 import Security from './components/Security'
 import Alerts from './components/Alerts'
-import Settings from './components/Settings'
 import ServerDashboard from './components/ServerDashboard'
 import Login from './components/Login'
 import { useUIStore } from './store/uiStore'
@@ -13,7 +12,7 @@ import { useAuthStore } from './store/authStore'
 
 const queryClient = new QueryClient()
 
-export type ViewType = 'dashboard' | 'logs' | 'infrastructure' | 'server' | 'security' | 'alerts' | 'settings'
+export type ViewType = 'dashboard' | 'logs' | 'infrastructure' | 'server' | 'security' | 'alerts'
 
 function AppInner() {
   const [currentView, setCurrentView] = useState<ViewType>('dashboard')
@@ -32,7 +31,6 @@ function AppInner() {
                                : <Infrastructure setView={setCurrentView} />
       case 'security':       return <Security setView={setCurrentView} />
       case 'alerts':         return <Alerts setView={setCurrentView} />
-      case 'settings':       return <Settings setView={setCurrentView} />
       default:               return <Dashboard setView={setCurrentView} />
     }
   }

--- a/frontend/src/components/Alerts.tsx
+++ b/frontend/src/components/Alerts.tsx
@@ -1,61 +1,239 @@
-import React from 'react';
-import Layout from './Layout';
-import type { ViewType } from '../App';
-import { AlertTriangle, Info, CheckCircle, Clock } from 'lucide-react';
+import React, { useState } from 'react'
+import Layout from './Layout'
+import type { ViewType } from '../App'
+import { AlertTriangle, CheckCircle, Clock, Plus, Trash2, X, Loader2 } from 'lucide-react'
+import { useUIStore } from '../store/uiStore'
+import { useAlertEvents, useAlertRules, useCreateAlertRule, useDeleteAlertRule } from '../hooks/useAlerts'
+import type { AlertRuleIn } from '../services/api'
 
 interface AlertsProps {
-    setView: (view: ViewType) => void;
+  setView: (view: ViewType) => void
+}
+
+const OPERATORS = ['>', '<', '>=', '<=', '==']
+const METRICS_COMMON = ['cpu_percent', 'memory_percent', 'disk_percent', 'load_1m']
+
+const severityBadge = (s: 'warning' | 'critical') =>
+  s === 'critical'
+    ? 'bg-red-500/10 text-red-400 border-red-500/20'
+    : 'bg-orange-500/10 text-orange-400 border-orange-500/20'
+
+function RuleForm({ serverId, onClose }: { serverId: string; onClose: () => void }) {
+  const create = useCreateAlertRule(serverId)
+  const [form, setForm] = useState<AlertRuleIn>({
+    metric_name: 'cpu_percent',
+    operator: '>',
+    threshold: 80,
+    severity: 'warning',
+    cooldown_minutes: 5,
+  })
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    create.mutate(form, { onSuccess: onClose })
+  }
+
+  const field = (label: string, node: React.ReactNode) => (
+    <label className="flex flex-col gap-1">
+      <span className="text-[11px] text-slate-400 uppercase tracking-widest font-bold">{label}</span>
+      {node}
+    </label>
+  )
+
+  const inputCls = 'bg-brand-slate border border-white/10 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-brand-purple/50 transition-all'
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <form
+        onSubmit={handleSubmit}
+        className="glass-card w-full max-w-md p-6 space-y-4 relative"
+      >
+        <div className="flex items-center justify-between mb-2">
+          <h3 className="text-base font-bold">Nova Regra de Alerta</h3>
+          <button type="button" onClick={onClose} className="text-slate-500 hover:text-white">
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {field('Métrica',
+          <input
+            list="metric-suggestions"
+            value={form.metric_name}
+            onChange={(e) => setForm({ ...form, metric_name: e.target.value })}
+            className={inputCls}
+            required
+          />
+        )}
+        <datalist id="metric-suggestions">
+          {METRICS_COMMON.map((m) => <option key={m} value={m} />)}
+        </datalist>
+
+        <div className="grid grid-cols-2 gap-3">
+          {field('Operador',
+            <select value={form.operator} onChange={(e) => setForm({ ...form, operator: e.target.value })} className={inputCls}>
+              {OPERATORS.map((o) => <option key={o}>{o}</option>)}
+            </select>
+          )}
+          {field('Threshold',
+            <input
+              type="number"
+              step="any"
+              value={form.threshold}
+              onChange={(e) => setForm({ ...form, threshold: parseFloat(e.target.value) })}
+              className={inputCls}
+              required
+            />
+          )}
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          {field('Severidade',
+            <select value={form.severity} onChange={(e) => setForm({ ...form, severity: e.target.value as 'warning' | 'critical' })} className={inputCls}>
+              <option value="warning">Warning</option>
+              <option value="critical">Critical</option>
+            </select>
+          )}
+          {field('Cooldown (min)',
+            <input
+              type="number"
+              min={1}
+              max={1440}
+              value={form.cooldown_minutes}
+              onChange={(e) => setForm({ ...form, cooldown_minutes: parseInt(e.target.value) })}
+              className={inputCls}
+              required
+            />
+          )}
+        </div>
+
+        <button
+          type="submit"
+          disabled={create.isPending}
+          className="w-full mt-2 py-2 rounded-lg bg-brand-purple hover:bg-brand-purple/80 text-white text-sm font-bold transition-all disabled:opacity-50 flex items-center justify-center gap-2"
+        >
+          {create.isPending && <Loader2 className="w-4 h-4 animate-spin" />}
+          Criar Regra
+        </button>
+        {create.isError && (
+          <p className="text-xs text-red-400 text-center">Erro ao criar regra. Verifique os campos.</p>
+        )}
+      </form>
+    </div>
+  )
 }
 
 const Alerts: React.FC<AlertsProps> = ({ setView }) => {
-    const alerts = [
-        { id: 1, type: 'CRIT', title: 'Mount Point Usage > 95%', desc: '/var/lib/postgresql no srv-db-01 está quase cheio.', time: 'Ago 12', color: 'text-red-500', bg: 'bg-red-500/10' },
-        { id: 2, type: 'WARN', title: 'High Load Average', desc: 'srv-mon-01 reportando carga de 12.4 no último minuto.', time: 'Ago 2h', color: 'text-orange-400', bg: 'bg-orange-400/10' },
-        { id: 3, type: 'INFO', title: 'Agente Atualizado', desc: 'Maestro-Agent v2.4.1 implantado com sucesso em 12 hosts.', time: 'Ago 5h', color: 'text-brand-purple', bg: 'bg-brand-purple/10' },
-        { id: 4, type: 'SUCC', title: 'Backup Diário Concluído', desc: 'Snapshot da infraestrutura Carvalima armazenado no S3.', time: 'Ontem', color: 'text-brand-neon', bg: 'bg-brand-neon/10' },
-    ];
+  const serverId = useUIStore((s) => s.selectedAgentId) ?? ''
+  const [showForm, setShowForm] = useState(false)
 
-    return (
-        <Layout currentView="alerts" setView={setView} title="Central de Incidentes">
-            <div className="max-w-3xl mx-auto space-y-4">
-                <div className="flex justify-between items-center mb-8">
-                    <div>
-                        <h2 className="text-xl font-bold">Notificações do Sistema</h2>
-                        <p className="text-xs text-slate-500 font-medium">Monitoramento de Infraestrutura &bull; Gestão Frota Carvalima</p>
+  const { data: eventsData, isLoading: loadingEvents } = useAlertEvents(serverId)
+  const { data: rulesData, isLoading: loadingRules } = useAlertRules(serverId)
+  const deleteRule = useDeleteAlertRule(serverId)
+
+  const fmt = (iso: string) => {
+    const d = new Date(iso)
+    return d.toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' })
+  }
+
+  return (
+    <Layout currentView="alerts" setView={setView} title="Central de Alertas">
+      {showForm && serverId && <RuleForm serverId={serverId} onClose={() => setShowForm(false)} />}
+
+      <div className="space-y-8">
+        {/* Rules */}
+        <section>
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-base font-bold text-slate-200">Regras Ativas</h2>
+            {serverId && (
+              <button
+                onClick={() => setShowForm(true)}
+                className="flex items-center gap-2 text-xs font-bold text-brand-purple bg-brand-purple/10 border border-brand-purple/20 px-3 py-1.5 rounded-lg hover:bg-brand-purple/20 transition-all"
+              >
+                <Plus className="w-3.5 h-3.5" />
+                Nova Regra
+              </button>
+            )}
+          </div>
+
+          {!serverId ? (
+            <p className="text-slate-500 text-sm">Selecione um servidor no Dashboard para gerenciar alertas.</p>
+          ) : loadingRules ? (
+            <div className="flex items-center gap-2 text-slate-500 text-sm"><Loader2 className="w-4 h-4 animate-spin" /> Carregando regras...</div>
+          ) : rulesData?.rules.length === 0 ? (
+            <p className="text-slate-500 text-sm">Nenhuma regra configurada.</p>
+          ) : (
+            <div className="space-y-2">
+              {rulesData?.rules.map((rule) => (
+                <div key={rule.rule_id} className="glass-card p-4 flex items-center gap-4">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="font-mono text-sm text-slate-200">{rule.metric_name}</span>
+                      <span className="font-mono text-brand-purple">{rule.operator}</span>
+                      <span className="font-mono text-slate-200">{rule.threshold}</span>
+                      <span className={`text-[10px] font-bold uppercase px-2 py-0.5 rounded-full border ${severityBadge(rule.severity)}`}>
+                        {rule.severity}
+                      </span>
                     </div>
-                    <button className="text-xs text-brand-purple bg-brand-purple/10 border border-brand-purple/20 px-3 py-1.5 rounded hover:bg-brand-purple/20 transition-all">
-                        Marcar tudo como lido
-                    </button>
+                    <p className="text-[11px] text-slate-500 mt-1">
+                      Cooldown {rule.cooldown_minutes}min &bull; Criado {fmt(rule.created_at)}
+                    </p>
+                  </div>
+                  <button
+                    onClick={() => deleteRule.mutate(rule.rule_id)}
+                    disabled={deleteRule.isPending}
+                    className="text-slate-600 hover:text-red-400 transition-colors shrink-0"
+                    title="Remover regra"
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </button>
                 </div>
-
-                {alerts.map(alert => (
-                    <div key={alert.id} className="glass-card p-5 group flex gap-5 hover:border-brand-purple/30 transition-all cursor-pointer">
-                        <div className={`shrink-0 w-12 h-12 rounded-xl flex items-center justify-center ${alert.bg} border border-white/5`}>
-                            {alert.type === 'CRIT' && <AlertTriangle className={`w-6 h-6 ${alert.color}`} />}
-                            {alert.type === 'WARN' && <AlertTriangle className={`w-6 h-6 ${alert.color}`} />}
-                            {alert.type === 'INFO' && <Info className={`w-6 h-6 ${alert.color}`} />}
-                            {alert.type === 'SUCC' && <CheckCircle className={`w-6 h-6 ${alert.color}`} />}
-                        </div>
-                        <div className="flex-1">
-                            <div className="flex justify-between items-start mb-1">
-                                <h4 className="font-bold text-sm text-slate-200 group-hover:text-white">{alert.title}</h4>
-                                <div className="flex items-center gap-1 text-[10px] text-slate-500 font-mono">
-                                    <Clock className="w-3 h-3" />
-                                    <span>{alert.time}</span>
-                                </div>
-                            </div>
-                            <p className="text-xs text-slate-400 leading-relaxed">{alert.desc}</p>
-                            <div className="mt-3 flex gap-2">
-                                <button className="text-[10px] font-bold text-brand-purple hover:underline">Investigar</button>
-                                <span className="text-slate-700">|</span>
-                                <button className="text-[10px] font-bold text-slate-500 hover:text-slate-300">Silenciar</button>
-                            </div>
-                        </div>
-                    </div>
-                ))}
+              ))}
             </div>
-        </Layout>
-    );
-};
+          )}
+        </section>
 
-export default Alerts;
+        {/* Events */}
+        <section>
+          <h2 className="text-base font-bold text-slate-200 mb-4">Histórico de Eventos</h2>
+
+          {!serverId ? null : loadingEvents ? (
+            <div className="flex items-center gap-2 text-slate-500 text-sm"><Loader2 className="w-4 h-4 animate-spin" /> Carregando eventos...</div>
+          ) : eventsData?.events.length === 0 ? (
+            <p className="text-slate-500 text-sm">Nenhum evento registrado.</p>
+          ) : (
+            <div className="space-y-2">
+              {eventsData?.events.map((event) => (
+                <div key={event.event_id} className="glass-card p-4 flex gap-4">
+                  <div className="shrink-0 mt-0.5">
+                    {event.state === 'FIRING'
+                      ? <AlertTriangle className={`w-4 h-4 ${event.severity === 'critical' ? 'text-red-400' : 'text-orange-400'}`} />
+                      : <CheckCircle className="w-4 h-4 text-brand-neon" />
+                    }
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="font-bold text-sm text-slate-200">{event.metric_name}</span>
+                      <span className={`text-[10px] font-bold uppercase px-2 py-0.5 rounded-full border ${event.state === 'FIRING' ? severityBadge(event.severity) : 'bg-brand-neon/10 text-brand-neon border-brand-neon/20'}`}>
+                        {event.state}
+                      </span>
+                    </div>
+                    <p className="text-xs text-slate-400 mt-0.5">
+                      Valor: <span className="font-mono text-slate-200">{event.value.toFixed(2)}</span>
+                      {' '}&bull; Threshold: <span className="font-mono text-slate-200">{event.threshold}</span>
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-1 text-[10px] text-slate-500 font-mono shrink-0">
+                    <Clock className="w-3 h-3" />
+                    <span>{fmt(event.triggered_at)}</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </Layout>
+  )
+}
+
+export default Alerts

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
     Terminal,
-    Settings,
     Shield,
     LayoutDashboard,
     Bell,
@@ -26,7 +25,6 @@ const Sidebar: React.FC<SidebarProps> = ({ currentView, setView }) => {
         { icon: Server, label: 'Infrastructure', id: 'infrastructure' },
         { icon: Shield, label: 'Security & Auth', id: 'security' },
         { icon: Bell, label: 'Alerts & Incidents', id: 'alerts' },
-        { icon: Settings, label: 'Telemetry Config', id: 'settings' },
     ];
 
     return (

--- a/frontend/src/hooks/useAlerts.ts
+++ b/frontend/src/hooks/useAlerts.ts
@@ -1,0 +1,34 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { alertsApi, type AlertRuleIn } from '../services/api'
+
+export const useAlertEvents = (serverId: string) =>
+  useQuery({
+    queryKey: ['alert-events', serverId],
+    queryFn: () => alertsApi.events(serverId),
+    enabled: !!serverId,
+    refetchInterval: 30_000,
+  })
+
+export const useAlertRules = (serverId: string) =>
+  useQuery({
+    queryKey: ['alert-rules', serverId],
+    queryFn: () => alertsApi.rules(serverId),
+    enabled: !!serverId,
+    staleTime: 60_000,
+  })
+
+export const useCreateAlertRule = (serverId: string) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (body: AlertRuleIn) => alertsApi.createRule(serverId, body),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['alert-rules', serverId] }),
+  })
+}
+
+export const useDeleteAlertRule = (serverId: string) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (ruleId: string) => alertsApi.deleteRule(serverId, ruleId),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['alert-rules', serverId] }),
+  })
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -126,3 +126,54 @@ export const authApi = {
   me: (): Promise<{ username: string }> =>
     http.get<{ username: string }>('/auth/me').then((r) => r.data),
 }
+
+export interface AlertEvent {
+  event_id: string
+  rule_id: string
+  metric_name: string
+  value: number
+  threshold: number
+  severity: 'warning' | 'critical'
+  state: 'FIRING' | 'RESOLVED'
+  triggered_at: string
+}
+
+export interface AlertRule {
+  rule_id: string
+  server_id: string
+  metric_name: string
+  operator: string
+  threshold: number
+  severity: 'warning' | 'critical'
+  cooldown_minutes: number
+  created_at: string
+}
+
+export interface AlertRuleIn {
+  metric_name: string
+  operator: string
+  threshold: number
+  severity: 'warning' | 'critical'
+  cooldown_minutes: number
+}
+
+export interface AlertEventsResponse {
+  server_id: string
+  events: AlertEvent[]
+}
+
+export interface AlertRulesResponse {
+  server_id: string
+  rules: AlertRule[]
+}
+
+export const alertsApi = {
+  events: (serverId: string, limit = 100): Promise<AlertEventsResponse> =>
+    http.get<AlertEventsResponse>(`/alerts/${serverId}/events`, { params: { limit } }).then((r) => r.data),
+  rules: (serverId: string): Promise<AlertRulesResponse> =>
+    http.get<AlertRulesResponse>(`/alerts/${serverId}/rules`).then((r) => r.data),
+  createRule: (serverId: string, body: AlertRuleIn): Promise<AlertRule> =>
+    http.post<AlertRule>(`/alerts/${serverId}/rules`, body).then((r) => r.data),
+  deleteRule: (serverId: string, ruleId: string): Promise<void> =>
+    http.delete(`/alerts/${serverId}/rules/${ruleId}`).then(() => undefined),
+}

--- a/migrations/003_create_alert_rules.sql
+++ b/migrations/003_create_alert_rules.sql
@@ -1,0 +1,21 @@
+-- Migration: 003_create_alert_rules
+-- Description: Stores configurable static threshold rules for the alerting engine.
+-- ReplacingMergeTree allows logical updates by inserting a new row with higher version.
+-- Run with: clickhouse-client --host <host> --port <port> --user <user> --password <password> --multiquery < migrations/003_create_alert_rules.sql
+
+CREATE TABLE IF NOT EXISTS maestro.alert_rules
+(
+    rule_id          UUID,
+    server_id        String,
+    metric_name      LowCardinality(String),
+    operator         String,                    -- '>', '<', '>=', '<='
+    threshold        Float64,
+    severity         LowCardinality(String),    -- 'warning', 'critical'
+    cooldown_minutes UInt32,
+    enabled          UInt8,
+    created_at       DateTime('UTC'),
+    version          UInt64                     -- unix ms; higher = newer record wins
+)
+ENGINE = ReplacingMergeTree(version)
+ORDER BY (server_id, rule_id)
+SETTINGS index_granularity = 8192;

--- a/migrations/004_create_alert_events.sql
+++ b/migrations/004_create_alert_events.sql
@@ -1,0 +1,22 @@
+-- Migration: 004_create_alert_events
+-- Description: Append-only log of alert state transitions (FIRING / RESOLVED).
+-- Each row is a discrete event; the full history is preserved for the dashboard.
+-- Run with: clickhouse-client --host <host> --port <port> --user <user> --password <password> --multiquery < migrations/004_create_alert_events.sql
+
+CREATE TABLE IF NOT EXISTS maestro.alert_events
+(
+    event_id     UUID,
+    rule_id      UUID,
+    server_id    String,
+    metric_name  LowCardinality(String),
+    value        Float64,
+    threshold    Float64,
+    severity     LowCardinality(String),  -- 'warning', 'critical'
+    state        LowCardinality(String),  -- 'FIRING', 'RESOLVED'
+    triggered_at DateTime('UTC')
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(triggered_at)
+ORDER BY (server_id, triggered_at)
+TTL triggered_at + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192;


### PR DESCRIPTION
## Summary

- Alerting engine completo com regras de threshold estático configuráveis por servidor
- State machine INACTIVE → FIRING → RESOLVED com deduplicação e cooldown por regra
- Persistência de regras via ClickHouse ReplacingMergeTree (soft-delete por versão)
- Persistência de eventos via ClickHouse MergeTree com TTL de 90 dias
- Estado em tempo real via Redis hash (`maestro:alert_state:{server_id}:{rule_id}`)
- API REST completa: GET/POST/DELETE de regras e GET de eventos por servidor
- Frontend com view de alertas funcional: regras ativas, criação via form modal, histórico de eventos
- Settings removido do sidebar (sem backend configurado ainda)

## Components Changed

- [ ] Agent (Go)
- [x] API (Python)
- [x] Frontend (React)
- [x] Infra / Config

## Test Plan

- [ ] Go: `go test ./...` passando
- [x] Python: sem erros de lint
- [x] Frontend: `npx tsc --noEmit` passando sem erros
- [ ] Testado manualmente (requer migrations no servidor)

## Notes

**Migrations necessárias antes do deploy:**
```bash
clickhouse-client --multiquery < migrations/003_create_alert_rules.sql
clickhouse-client --multiquery < migrations/004_create_alert_events.sql
```

**Avaliador:** roda a cada 30s, itera todos os servidores com heartbeat ativo, avalia cada regra habilitada contra o MAX da métrica nos últimos 5 minutos.

**Cooldown:** após RESOLVED, não re-dispara FIRING até expirar o cooldown configurado na regra (1–1440 min).

**Trade-off do `get_latest_metric_value`:** usa MAX nos últimos 5 minutos (não o valor mais recente) para evitar falsos disparos por spike momentâneo. Pode ser ajustado para `argMax` se precisarmos de pontualidade.

Closes #17
Closes #18