### PR TITLE
feat(ml): Isolation Forest anomaly detection + model persistence

### DIFF
--- a/api/app/clickhouse.py
+++ b/api/app/clickhouse.py
@@ -23,6 +23,7 @@ _FEATURE_INSERT_COLUMNS = [
     "rolling_mean_5m", "rolling_std_5m", "rate_of_change",
     "hour_sin", "hour_cos", "day_of_week", "is_weekend",
 ]
+_SCORE_INSERT_COLUMNS = ["server_id", "metric_name", "timestamp", "score", "model_version"]
 
 
 @dataclass
@@ -194,6 +195,36 @@ class ClickHouseWriter:
             event.value, event.threshold, event.severity, event.state, event.triggered_at,
         ]]
         await self._client.insert("alert_events", data=data, column_names=_EVENT_INSERT_COLUMNS)
+
+    async def insert_anomaly_scores(
+        self,
+        server_id: str,
+        metric_name: str,
+        timestamps: list,
+        scores: list[float],
+        model_version: str,
+    ) -> None:
+        """Bulk-insert anomaly scores produced by the Isolation Forest model."""
+        if not timestamps:
+            return
+        data = [
+            [server_id, metric_name, ts, score, model_version]
+            for ts, score in zip(timestamps, scores)
+        ]
+        delay = 1.0
+        for attempt in range(1, 4):
+            try:
+                await self._client.insert(
+                    "anomaly_scores", data=data, column_names=_SCORE_INSERT_COLUMNS
+                )
+                logger.debug("clickhouse: inserted %d anomaly scores", len(data))
+                return
+            except Exception as exc:
+                if attempt == 3:
+                    logger.error("clickhouse: anomaly score insert failed after 3 attempts: %s", exc)
+                    return
+                logger.warning("clickhouse: score insert attempt %d/3: %s — retrying", attempt, exc)
+                await asyncio.sleep(delay * (2 ** (attempt - 1)))
 
     async def close(self) -> None:
         if self._client is not None:
@@ -416,6 +447,62 @@ class ClickHouseReader:
         if hasattr(ts, "tzinfo") and ts.tzinfo is None:
             ts = ts.replace(tzinfo=timezone.utc)
         return ts
+
+    async def get_features_for_training(
+        self,
+        server_id: str,
+        metric_name: str,
+    ):
+        """Return a pandas DataFrame of all metric_features rows for model training.
+
+        Fetches all available history (up to 90-day TTL). Returns None if pandas
+        is not importable or if no rows are found.
+        """
+        try:
+            import pandas as pd
+        except ImportError:
+            logger.error("clickhouse: pandas not installed — cannot fetch training features")
+            return None
+
+        result = await self._client.query(
+            "SELECT timestamp, raw_value,"
+            "       rolling_mean_5m, rolling_std_5m, rate_of_change,"
+            "       hour_sin, hour_cos, day_of_week, is_weekend"
+            " FROM metric_features"
+            " WHERE server_id = {server_id:String}"
+            "   AND metric_name = {metric_name:String}"
+            " ORDER BY timestamp",
+            parameters={"server_id": server_id, "metric_name": metric_name},
+        )
+        if not result.result_rows:
+            return None
+
+        cols = [
+            "timestamp", "raw_value",
+            "rolling_mean_5m", "rolling_std_5m", "rate_of_change",
+            "hour_sin", "hour_cos", "day_of_week", "is_weekend",
+        ]
+        df = pd.DataFrame(result.result_rows, columns=cols)
+        df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True)
+        return df
+
+    async def get_anomaly_scores(
+        self,
+        server_id: str,
+        metric_name: str,
+        minutes: int,
+    ) -> list[tuple]:
+        """Return (timestamp, score) pairs for the last N minutes."""
+        result = await self._client.query(
+            "SELECT timestamp, score"
+            " FROM anomaly_scores FINAL"
+            " WHERE server_id = {server_id:String}"
+            "   AND metric_name = {metric_name:String}"
+            "   AND timestamp >= now() - INTERVAL {minutes:UInt32} MINUTE"
+            " ORDER BY timestamp",
+            parameters={"server_id": server_id, "metric_name": metric_name, "minutes": minutes},
+        )
+        return [(row[0], float(row[1])) for row in result.result_rows]
 
     async def close(self) -> None:
         if self._client is not None:

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -47,6 +47,10 @@ class Settings(BaseSettings):
     jwt_secret: str = "change-me-before-deploy"
     jwt_expire_minutes: int = 1440  # 24 hours
 
+    # ML
+    ml_contamination: float = 0.05   # expected anomaly fraction for Isolation Forest
+    ml_models_dir: str = "/opt/maestro/models"  # directory for persisted model files
+
     model_config = {"env_prefix": "MAESTRO_", "env_file": str(_ENV_FILE), "env_file_encoding": "utf-8"}
 
 

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -4,8 +4,13 @@ from contextlib import asynccontextmanager
 
 from fastapi import Depends, FastAPI
 
+from pathlib import Path
+
 from app.alert_evaluator import run_alert_evaluator
+from app.config import settings
 from app.feature_engineering import run_feature_pipeline
+from app.ml.anomaly_detector import run_anomaly_detector
+from app.ml.model_store import ModelStore
 from app.alerts import router as alerts_router
 from app.auth import get_current_user
 from app.auth import router as auth_router
@@ -36,18 +41,24 @@ async def lifespan(app: FastAPI):
     app.state.ch_reader = reader
     app.state.ch_writer = writer
 
+    # Initialise ML model store and load any persisted models from disk.
+    store = ModelStore(Path(settings.ml_models_dir))
+    store.load_all()
+    app.state.model_store = store
+
     # Start background consumers.
     metrics_task = asyncio.create_task(run_consumer(writer), name="metrics-consumer")
     heartbeat_task = asyncio.create_task(run_heartbeat_consumer(), name="heartbeat-consumer")
     log_task = asyncio.create_task(run_log_consumer(writer), name="log-consumer")
     alert_task = asyncio.create_task(run_alert_evaluator(reader, writer), name="alert-evaluator")
     feature_task = asyncio.create_task(run_feature_pipeline(reader, writer), name="feature-pipeline")
-    logger.info("app: metrics, heartbeat, log consumers, alert evaluator and feature pipeline started")
+    detector_task = asyncio.create_task(run_anomaly_detector(reader, writer, store), name="anomaly-detector")
+    logger.info("app: all consumers, alert evaluator, feature pipeline and anomaly detector started")
 
     yield
 
     # Graceful shutdown.
-    for task in (metrics_task, heartbeat_task, log_task, alert_task, feature_task):
+    for task in (metrics_task, heartbeat_task, log_task, alert_task, feature_task, detector_task):
         task.cancel()
         try:
             await task

--- a/api/app/ml/anomaly_detector.py
+++ b/api/app/ml/anomaly_detector.py
@@ -1,0 +1,186 @@
+"""
+Isolation Forest anomaly detection — issue #22.
+
+Background task that trains one IsolationForest model per (server_id, metric_name)
+using pre-computed features from metric_features, persists the model via ModelStore,
+and writes normalised anomaly scores to the anomaly_scores ClickHouse table.
+
+Training cadence: every 24 hours.
+Minimum samples: 500 data points (logs a warning and skips if below threshold).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from datetime import datetime, timezone
+
+import numpy as np
+import pandas as pd
+from sklearn.ensemble import IsolationForest
+
+from app.ml.model_store import ModelMetadata, ModelStore
+
+logger = logging.getLogger(__name__)
+
+_TRAINING_INTERVAL_SECONDS = 86_400   # 24 hours
+_MIN_SAMPLES = 500                     # minimum rows in metric_features to train
+
+FEATURE_COLUMNS = [
+    "rolling_mean_5m",
+    "rolling_std_5m",
+    "rate_of_change",
+    "hour_sin",
+    "hour_cos",
+    "day_of_week",
+    "is_weekend",
+]
+
+
+def _get_contamination() -> float:
+    try:
+        c = float(os.getenv("MAESTRO_ML_CONTAMINATION", "0.05"))
+        return max(0.01, min(c, 0.5))
+    except ValueError:
+        return 0.05
+
+
+def train_model(
+    features_df: pd.DataFrame,
+    server_id: str,
+    metric_name: str,
+    contamination: float,
+) -> tuple[IsolationForest, ModelMetadata]:
+    """
+    Train an IsolationForest on a feature DataFrame and return the fitted model
+    together with its metadata (score normalisation bounds included).
+
+    Pure function — no I/O, fully unit-testable.
+
+    Args:
+        features_df: DataFrame with at minimum the FEATURE_COLUMNS columns
+                     plus a 'timestamp' column (tz-aware UTC).
+        server_id:   Server identifier.
+        metric_name: Metric name.
+        contamination: Expected fraction of outliers in [0.01, 0.5].
+
+    Returns:
+        (fitted_model, ModelMetadata)
+    """
+    X = features_df[FEATURE_COLUMNS].values.astype(np.float64)
+
+    model = IsolationForest(
+        contamination=contamination,
+        random_state=42,
+        n_jobs=1,  # VPS has 1 vCPU — no benefit from parallelism
+    )
+    model.fit(X)
+
+    # Compute score normalisation bounds from training set
+    scores = model.decision_function(X)
+    score_min = float(scores.min())
+    score_max = float(scores.max())
+
+    timestamps = pd.to_datetime(features_df["timestamp"], utc=True)
+    now = datetime.now(tz=timezone.utc).isoformat()
+
+    metadata = ModelMetadata(
+        server_id=server_id,
+        metric_name=metric_name,
+        trained_at=now,
+        data_range_start=timestamps.min().isoformat(),
+        data_range_end=timestamps.max().isoformat(),
+        n_samples=len(X),
+        contamination=contamination,
+        score_min=score_min,
+        score_max=score_max,
+        version=now,
+    )
+
+    return model, metadata
+
+
+def score_dataframe(
+    model: IsolationForest,
+    metadata: ModelMetadata,
+    features_df: pd.DataFrame,
+) -> np.ndarray:
+    """
+    Score a feature DataFrame using a fitted model.
+
+    Returns a numpy array of normalised scores in [0, 1] (1 = most anomalous),
+    one value per row in features_df.
+    """
+    X = features_df[FEATURE_COLUMNS].values.astype(np.float64)
+    raw = model.decision_function(X)
+    score_range = metadata.score_max - metadata.score_min
+    if score_range == 0.0:
+        return np.full(len(X), 0.5)
+    normalized = (metadata.score_max - raw) / score_range
+    return np.clip(normalized, 0.0, 1.0)
+
+
+async def _process_one(
+    reader,
+    writer,
+    store: ModelStore,
+    server_id: str,
+    metric_name: str,
+) -> bool:
+    """Train, persist, and score one (server_id, metric_name). Returns True if trained."""
+    features_df = await reader.get_features_for_training(server_id, metric_name)
+
+    if features_df is None or len(features_df) < _MIN_SAMPLES:
+        n = len(features_df) if features_df is not None else 0
+        logger.debug(
+            "anomaly-detector: %s/%s has %d samples (min=%d) — skipping",
+            server_id, metric_name, n, _MIN_SAMPLES,
+        )
+        return False
+
+    contamination = _get_contamination()
+
+    try:
+        model, metadata = train_model(features_df, server_id, metric_name, contamination)
+        store.save(server_id, metric_name, model, metadata)
+    except Exception as exc:
+        logger.error("anomaly-detector: training failed for %s/%s: %s", server_id, metric_name, exc)
+        return False
+
+    # Score all training rows and persist to anomaly_scores
+    scores = score_dataframe(model, metadata, features_df)
+    timestamps = pd.to_datetime(features_df["timestamp"], utc=True).tolist()
+    await writer.insert_anomaly_scores(
+        server_id, metric_name, timestamps, scores.tolist(), metadata.version
+    )
+
+    logger.info(
+        "anomaly-detector: trained %s/%s — n=%d contamination=%.2f",
+        server_id, metric_name, metadata.n_samples, contamination,
+    )
+    return True
+
+
+async def run_anomaly_detector(reader, writer, store: ModelStore) -> None:
+    """
+    Background task: train Isolation Forest models for all known servers/metrics,
+    then repeat every 24 hours.
+    """
+    logger.info("anomaly-detector: starting")
+    while True:
+        try:
+            servers = await reader.get_known_server_ids()
+            trained = 0
+            for server_id in servers:
+                metrics = await reader.get_metric_names(server_id)
+                for metric_name in metrics:
+                    if await _process_one(reader, writer, store, server_id, metric_name):
+                        trained += 1
+            logger.info("anomaly-detector: cycle complete — %d model(s) trained/updated", trained)
+        except asyncio.CancelledError:
+            logger.info("anomaly-detector: cancelled, shutting down")
+            return
+        except Exception as exc:
+            logger.error("anomaly-detector: unexpected error: %s", exc, exc_info=True)
+
+        await asyncio.sleep(_TRAINING_INTERVAL_SECONDS)

--- a/api/app/ml/model_store.py
+++ b/api/app/ml/model_store.py
@@ -1,0 +1,166 @@
+"""
+Model persistence for Maestro ML — issue #24.
+
+ModelStore manages the lifecycle of trained IsolationForest models:
+  - Saves models with a blue/green swap (write to .new.pkl, validate, rename)
+  - Stores a JSON metadata sidecar alongside each model
+  - Loads all persisted models into memory on startup
+  - Provides thread-safe in-memory scoring via get() / score()
+
+Directory layout on disk:
+  {models_dir}/
+    {server_id}/
+      {metric_name}.pkl       ← active model (joblib)
+      {metric_name}.json      ← metadata sidecar
+      {metric_name}.new.pkl   ← staging (only present during swap)
+      {metric_name}.new.json  ← staging (only present during swap)
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import joblib
+import numpy as np
+from sklearn.ensemble import IsolationForest
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ModelMetadata:
+    server_id: str
+    metric_name: str
+    trained_at: str         # ISO-8601 UTC
+    data_range_start: str   # ISO-8601 UTC
+    data_range_end: str     # ISO-8601 UTC
+    n_samples: int
+    contamination: float
+    score_min: float        # decision_function min on training set (most anomalous)
+    score_max: float        # decision_function max on training set (most normal)
+    version: str            # same as trained_at — used to tag anomaly_scores rows
+
+
+_ModelEntry = tuple[IsolationForest, ModelMetadata]
+
+
+class ModelStore:
+    """In-memory registry of trained IsolationForest models with disk persistence."""
+
+    def __init__(self, models_dir: Path | None = None) -> None:
+        self._dir = models_dir or Path(os.getenv("MAESTRO_MODELS_DIR", "/opt/maestro/models"))
+        self._models: dict[tuple[str, str], _ModelEntry] = {}
+
+    # ── Startup ───────────────────────────────────────────────────────────────
+
+    def load_all(self) -> int:
+        """Scan models_dir and load all valid persisted models into memory.
+
+        Returns the number of models successfully loaded.
+        """
+        if not self._dir.exists():
+            logger.info("model_store: models_dir %s does not exist — no models loaded", self._dir)
+            return 0
+
+        count = 0
+        for pkl_path in sorted(self._dir.glob("*/*.pkl")):
+            if ".new" in pkl_path.name:
+                continue  # skip staging artefacts from a previous crashed swap
+            meta_path = pkl_path.with_suffix(".json")
+            if not meta_path.exists():
+                logger.warning("model_store: %s has no metadata sidecar — skipping", pkl_path)
+                continue
+            try:
+                model: IsolationForest = joblib.load(pkl_path)
+                meta = ModelMetadata(**json.loads(meta_path.read_text(encoding="utf-8")))
+                self._models[(meta.server_id, meta.metric_name)] = (model, meta)
+                count += 1
+                logger.debug("model_store: loaded %s/%s (n_samples=%d)",
+                             meta.server_id, meta.metric_name, meta.n_samples)
+            except Exception as exc:
+                logger.warning("model_store: failed to load %s: %s", pkl_path, exc)
+
+        logger.info("model_store: loaded %d model(s) from %s", count, self._dir)
+        return count
+
+    # ── Read ──────────────────────────────────────────────────────────────────
+
+    def get(self, server_id: str, metric_name: str) -> _ModelEntry | None:
+        return self._models.get((server_id, metric_name))
+
+    def score(self, server_id: str, metric_name: str, features: np.ndarray) -> float | None:
+        """Return a normalised anomaly score in [0, 1] for a feature vector.
+
+        Returns None if no model is loaded for this (server_id, metric_name).
+        Score semantics: 0.0 = most normal, 1.0 = most anomalous.
+        """
+        entry = self.get(server_id, metric_name)
+        if entry is None:
+            return None
+        model, meta = entry
+        raw = model.decision_function(features.reshape(1, -1))[0]
+        score_range = meta.score_max - meta.score_min
+        if score_range == 0.0:
+            return 0.5
+        normalized = (meta.score_max - raw) / score_range
+        return float(np.clip(normalized, 0.0, 1.0))
+
+    # ── Write ─────────────────────────────────────────────────────────────────
+
+    def save(
+        self,
+        server_id: str,
+        metric_name: str,
+        model: IsolationForest,
+        metadata: ModelMetadata,
+    ) -> None:
+        """Persist model with a blue/green swap and update the in-memory registry.
+
+        Steps:
+          1. Serialise to {metric_name}.new.pkl + {metric_name}.new.json
+          2. Reload from disk and score a dummy point to validate integrity
+          3. Atomically rename .new.pkl → .pkl and .new.json → .json
+          4. Update in-memory registry
+
+        Raises RuntimeError if validation fails; staging files are cleaned up.
+        """
+        model_dir = self._dir / server_id
+        model_dir.mkdir(parents=True, exist_ok=True)
+
+        final_pkl = model_dir / f"{metric_name}.pkl"
+        final_json = model_dir / f"{metric_name}.json"
+        staging_pkl = model_dir / f"{metric_name}.new.pkl"
+        staging_json = model_dir / f"{metric_name}.new.json"
+
+        # Write staging
+        joblib.dump(model, staging_pkl, compress=3)
+        staging_json.write_text(
+            json.dumps(asdict(metadata), indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+        # Validate: reload from disk and run a dummy inference
+        try:
+            reloaded: IsolationForest = joblib.load(staging_pkl)
+            dummy = np.zeros((1, model.n_features_in_))
+            reloaded.decision_function(dummy)
+        except Exception as exc:
+            staging_pkl.unlink(missing_ok=True)
+            staging_json.unlink(missing_ok=True)
+            raise RuntimeError(
+                f"model_store: validation failed for {server_id}/{metric_name}: {exc}"
+            ) from exc
+
+        # Atomic swap
+        staging_pkl.replace(final_pkl)
+        staging_json.replace(final_json)
+
+        # Update registry
+        self._models[(server_id, metric_name)] = (model, metadata)
+        logger.info(
+            "model_store: saved %s/%s — n_samples=%d trained_at=%s",
+            server_id, metric_name, metadata.n_samples, metadata.trained_at,
+        )

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -11,3 +11,5 @@ python-jose[cryptography]
 bcrypt
 pandas
 numpy
+scikit-learn
+joblib

--- a/api/tests/test_anomaly_detector.py
+++ b/api/tests/test_anomaly_detector.py
@@ -1,0 +1,194 @@
+"""
+Unit tests for Isolation Forest training, scoring, and model persistence.
+No ClickHouse or network required — all I/O is mocked or uses tmp_path.
+"""
+from __future__ import annotations
+
+import json
+import math
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.ensemble import IsolationForest
+
+from app.ml.anomaly_detector import (
+    FEATURE_COLUMNS,
+    score_dataframe,
+    train_model,
+)
+from app.ml.model_store import ModelMetadata, ModelStore
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+def _synthetic_features(n: int = 600, seed: int = 0) -> pd.DataFrame:
+    """
+    Generate n rows of synthetic feature data representing normal server behaviour.
+    Timestamps are 15s apart starting from a fixed Monday 10:00 UTC.
+    """
+    rng = np.random.default_rng(seed)
+    start = datetime(2026, 5, 11, 10, 0, 0, tzinfo=timezone.utc)
+    timestamps = [start + timedelta(seconds=i * 15) for i in range(n)]
+
+    hour_frac = np.array([t.hour + t.minute / 60 for t in timestamps])
+    radians = 2 * math.pi * hour_frac / 24
+
+    df = pd.DataFrame({
+        "timestamp": timestamps,
+        "raw_value": rng.normal(50.0, 5.0, n),
+        "rolling_mean_5m": rng.normal(50.0, 3.0, n),
+        "rolling_std_5m": rng.uniform(0.5, 3.0, n),
+        "rate_of_change": rng.normal(0.0, 0.1, n),
+        "hour_sin": np.sin(radians),
+        "hour_cos": np.cos(radians),
+        "day_of_week": np.array([t.weekday() for t in timestamps], dtype=np.uint8),
+        "is_weekend": np.array([int(t.weekday() >= 5) for t in timestamps], dtype=np.uint8),
+    })
+    return df
+
+
+# ── train_model ───────────────────────────────────────────────────────────────
+
+class TestTrainModel:
+    def test_returns_fitted_model_and_metadata(self):
+        df = _synthetic_features(600)
+        model, meta = train_model(df, "srv", "cpu_usage_percent", contamination=0.05)
+        assert isinstance(model, IsolationForest)
+        assert isinstance(meta, ModelMetadata)
+
+    def test_metadata_fields_present(self):
+        df = _synthetic_features(600)
+        _, meta = train_model(df, "srv", "cpu_usage_percent", contamination=0.05)
+        assert meta.server_id == "srv"
+        assert meta.metric_name == "cpu_usage_percent"
+        assert meta.n_samples == 600
+        assert meta.contamination == pytest.approx(0.05)
+        assert meta.trained_at != ""
+        assert meta.data_range_start != ""
+        assert meta.data_range_end != ""
+        assert meta.score_min < meta.score_max  # meaningful normalisation bounds
+
+    def test_model_has_correct_feature_count(self):
+        df = _synthetic_features(600)
+        model, _ = train_model(df, "srv", "cpu", contamination=0.05)
+        assert model.n_features_in_ == len(FEATURE_COLUMNS)
+
+    def test_score_bounds_from_training_set(self):
+        df = _synthetic_features(600)
+        _, meta = train_model(df, "srv", "cpu", contamination=0.05)
+        assert meta.score_min <= meta.score_max
+
+
+# ── score_dataframe ───────────────────────────────────────────────────────────
+
+class TestScoreDataframe:
+    def test_scores_in_unit_range(self):
+        df = _synthetic_features(600)
+        model, meta = train_model(df, "srv", "cpu", contamination=0.05)
+        scores = score_dataframe(model, meta, df)
+        assert scores.min() >= 0.0
+        assert scores.max() <= 1.0
+
+    def test_output_length_matches_input(self):
+        df = _synthetic_features(600)
+        model, meta = train_model(df, "srv", "cpu", contamination=0.05)
+        scores = score_dataframe(model, meta, df)
+        assert len(scores) == len(df)
+
+    def test_anomaly_scores_higher_than_normal(self):
+        """Injected spike rows should score higher than normal rows."""
+        rng = np.random.default_rng(42)
+        normal_df = _synthetic_features(800)
+        model, meta = train_model(normal_df, "srv", "cpu", contamination=0.05)
+
+        # Normal test rows
+        normal_test = _synthetic_features(50, seed=99)
+        normal_scores = score_dataframe(model, meta, normal_test)
+
+        # Anomalous rows: extreme values on all features
+        anomaly_df = normal_test.copy()
+        for col in ["rolling_mean_5m", "rolling_std_5m", "rate_of_change", "raw_value"]:
+            anomaly_df[col] = anomaly_df[col] * 10 + 200
+        anomaly_scores = score_dataframe(model, meta, anomaly_df)
+
+        assert anomaly_scores.mean() > normal_scores.mean()
+
+
+# ── ModelStore ────────────────────────────────────────────────────────────────
+
+class TestModelStore:
+    def test_get_returns_none_when_no_model(self, tmp_path):
+        store = ModelStore(tmp_path)
+        assert store.get("unknown", "cpu_usage_percent") is None
+
+    def test_score_returns_none_without_model(self, tmp_path):
+        store = ModelStore(tmp_path)
+        features = np.zeros(len(FEATURE_COLUMNS))
+        assert store.score("srv", "cpu", features) is None
+
+    def test_save_and_load_roundtrip(self, tmp_path):
+        df = _synthetic_features(600)
+        model, meta = train_model(df, "srv", "cpu_usage_percent", contamination=0.05)
+
+        store = ModelStore(tmp_path)
+        store.save("srv", "cpu_usage_percent", model, meta)
+
+        # Reload from a fresh store instance
+        store2 = ModelStore(tmp_path)
+        count = store2.load_all()
+        assert count == 1
+        entry = store2.get("srv", "cpu_usage_percent")
+        assert entry is not None
+        loaded_model, loaded_meta = entry
+        assert loaded_meta.n_samples == 600
+        assert loaded_meta.server_id == "srv"
+
+    def test_blue_green_staging_files_removed_after_save(self, tmp_path):
+        df = _synthetic_features(600)
+        model, meta = train_model(df, "srv", "cpu", contamination=0.05)
+        store = ModelStore(tmp_path)
+        store.save("srv", "cpu", model, meta)
+
+        # No .new.pkl or .new.json should remain
+        staging = list(tmp_path.glob("**/*.new.*"))
+        assert staging == []
+
+    def test_final_pkl_exists_after_save(self, tmp_path):
+        df = _synthetic_features(600)
+        model, meta = train_model(df, "srv", "cpu", contamination=0.05)
+        store = ModelStore(tmp_path)
+        store.save("srv", "cpu", model, meta)
+        assert (tmp_path / "srv" / "cpu.pkl").exists()
+        assert (tmp_path / "srv" / "cpu.json").exists()
+
+    def test_metadata_json_is_valid(self, tmp_path):
+        df = _synthetic_features(600)
+        model, meta = train_model(df, "srv", "cpu", contamination=0.05)
+        store = ModelStore(tmp_path)
+        store.save("srv", "cpu", model, meta)
+        raw = json.loads((tmp_path / "srv" / "cpu.json").read_text())
+        for field in ("server_id", "metric_name", "trained_at", "n_samples",
+                      "contamination", "score_min", "score_max", "version"):
+            assert field in raw
+
+    def test_score_in_unit_range_after_save(self, tmp_path):
+        df = _synthetic_features(600)
+        model, meta = train_model(df, "srv", "cpu", contamination=0.05)
+        store = ModelStore(tmp_path)
+        store.save("srv", "cpu", model, meta)
+
+        features = df[FEATURE_COLUMNS].values[0]
+        score = store.score("srv", "cpu", features)
+        assert score is not None
+        assert 0.0 <= score <= 1.0
+
+    def test_load_all_empty_dir(self, tmp_path):
+        store = ModelStore(tmp_path)
+        assert store.load_all() == 0
+
+    def test_load_all_nonexistent_dir(self, tmp_path):
+        store = ModelStore(tmp_path / "does_not_exist")
+        assert store.load_all() == 0

--- a/migrations/006_create_anomaly_scores.sql
+++ b/migrations/006_create_anomaly_scores.sql
@@ -1,0 +1,27 @@
+-- Migration: 006_create_anomaly_scores
+-- Description: Stores per-datapoint anomaly scores produced by the Isolation Forest model.
+-- One row per (server_id, metric_name, timestamp) — score in [0, 1] where 1 = most anomalous.
+-- Engine: ReplacingMergeTree so re-scoring with a newer model version replaces the old score
+--         for the same timestamp without duplicating rows.
+
+CREATE TABLE IF NOT EXISTS maestro.anomaly_scores
+(
+    server_id     LowCardinality(String),
+    metric_name   LowCardinality(String),
+
+    -- UTC timestamp matching the source metric_features row.
+    timestamp     DateTime64(3, 'UTC'),
+
+    -- Anomaly score in [0.0, 1.0]. 0 = normal, 1 = most anomalous.
+    -- Normalised from IsolationForest.decision_function() using training-set min/max.
+    score         Float64,
+
+    -- ISO-8601 UTC string identifying which model run produced this score.
+    -- Used to audit score provenance and filter stale scores after retraining.
+    model_version String
+)
+ENGINE = ReplacingMergeTree()
+PARTITION BY toYYYYMM(timestamp)
+ORDER BY (server_id, metric_name, timestamp)
+TTL timestamp + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192;


### PR DESCRIPTION
## Summary

- **#22 Isolation Forest**: trains one model per `(server_id, metric_name)` using 7 pre-computed features from `metric_features`; normalised anomaly score `[0, 1]` written to `anomaly_scores` after each training run
- **#24 Model persistence**: `ModelStore` manages in-memory registry + disk persistence with blue/green swap — writes to `.new.pkl`, validates via dummy inference, renames atomically; JSON metadata sidecar includes `trained_at`, `score_min/max`, `n_samples`, `contamination`
- Models load automatically at API startup; `run_anomaly_detector` background task trains/retrains every 24h
- `MAESTRO_ML_CONTAMINATION` (default `0.05`) and `MAESTRO_MODELS_DIR` (default `/opt/maestro/models`) configurable via env / `.env`

## Components Changed

- [ ] Agent (Go)
- [x] API (Python)
- [ ] Frontend (React)
- [x] Infra / Config

## Test Plan

- [ ] Go: `go test ./...` passando
- [x] Python: `32/32` tests passing (`pytest tests/`)
- [ ] Frontend: `npm run type-check` passando
- [ ] Testado manualmente

## Notes

**Score normalisation:** `IsolationForest.decision_function()` is unbounded. During training, `score_min` and `score_max` from the training set are stored in metadata and used at inference time: `score = clip((score_max - raw) / (score_range), 0, 1)`. This gives a calibrated [0, 1] range relative to what the model saw during training.

**`n_jobs=1`:** VPS has 1 vCPU — parallelism would only add overhead.

**Minimum samples:** 500 rows required to train (logged at DEBUG level if skipped). With 15s interval and 6 metrics, the VPS accumulates this in ~21 minutes of real data.

**Next:** #23 dynamic alert thresholds — `anomaly_scores` table is now populated and ready to drive ML-based firing rules.

Closes #22
Closes #24