### PR TITLE
feat(ml): Phase 3 — dynamic thresholds, River online ML, anomaly visualization

### DIFF
--- a/api/app/alert_evaluator.py
+++ b/api/app/alert_evaluator.py
@@ -68,7 +68,22 @@ async def _evaluate_rule(
         logger.warning("alert_evaluator: unknown operator %r in rule %s", rule.operator, rule.rule_id)
         return
 
-    breached = compare(value, rule.threshold)
+    mode = rule.alert_mode or "static"
+
+    # Static threshold evaluation
+    static_breached = compare(value, rule.threshold) if mode in ("static", "both") else False
+
+    # ML score evaluation
+    ml_breached = False
+    if mode in ("ml", "both"):
+        score = await reader.get_latest_anomaly_score(rule.server_id, rule.metric_name)
+        if score is not None:
+            ml_breached = score >= rule.ml_score_threshold
+        elif mode == "ml":
+            # Fallback: no model available — evaluate statically
+            static_breached = compare(value, rule.threshold)
+
+    breached = static_breached or ml_breached
     state_key = f"maestro:alert_state:{rule.server_id}:{rule.rule_id}"
     raw = await redis.get(state_key)
     current: dict = json.loads(raw) if raw else {

--- a/api/app/alerts.py
+++ b/api/app/alerts.py
@@ -21,6 +21,8 @@ class AlertRuleIn(BaseModel):
     threshold: float
     severity: str = Field(pattern=r"^(warning|critical)$")
     cooldown_minutes: int = Field(default=5, ge=1, le=1440)
+    alert_mode: str = Field(default="static", pattern=r"^(static|ml|both)$")
+    ml_score_threshold: float = Field(default=0.7, ge=0.0, le=1.0)
 
 
 class AlertRuleOut(BaseModel):
@@ -32,6 +34,8 @@ class AlertRuleOut(BaseModel):
     severity: str
     cooldown_minutes: int
     created_at: str
+    alert_mode: str
+    ml_score_threshold: float
 
 
 class AlertEventOut(BaseModel):
@@ -113,6 +117,8 @@ async def create_alert_rule(server_id: str, body: AlertRuleIn, request: Request)
         cooldown_minutes=body.cooldown_minutes,
         enabled=True,
         created_at=now,
+        alert_mode=body.alert_mode,
+        ml_score_threshold=body.ml_score_threshold,
     )
     await writer.insert_alert_rule(rule)
     return _rule_out(rule)
@@ -136,6 +142,8 @@ async def delete_alert_rule(server_id: str, rule_id: str, request: Request) -> N
         threshold=target.threshold, severity=target.severity,
         cooldown_minutes=target.cooldown_minutes, enabled=False,
         created_at=target.created_at,
+        alert_mode=target.alert_mode,
+        ml_score_threshold=target.ml_score_threshold,
     )
     await writer.insert_alert_rule(disabled)
 
@@ -189,4 +197,6 @@ def _rule_out(r: AlertRule) -> AlertRuleOut:
         severity=r.severity,
         cooldown_minutes=r.cooldown_minutes,
         created_at=_utc_iso(r.created_at),
+        alert_mode=r.alert_mode,
+        ml_score_threshold=r.ml_score_threshold,
     )

--- a/api/app/clickhouse.py
+++ b/api/app/clickhouse.py
@@ -15,7 +15,8 @@ logger = logging.getLogger(__name__)
 _INSERT_COLUMNS = ["server_id", "metric_name", "value", "timestamp", "tags"]
 _LOG_INSERT_COLUMNS = ["server_id", "log_file", "timestamp", "line"]
 _RULE_INSERT_COLUMNS = ["rule_id", "server_id", "metric_name", "operator", "threshold",
-                        "severity", "cooldown_minutes", "enabled", "created_at", "version"]
+                        "severity", "cooldown_minutes", "enabled", "created_at", "version",
+                        "alert_mode", "ml_score_threshold"]
 _EVENT_INSERT_COLUMNS = ["event_id", "rule_id", "server_id", "metric_name",
                          "value", "threshold", "severity", "state", "triggered_at"]
 _FEATURE_INSERT_COLUMNS = [
@@ -60,6 +61,8 @@ class AlertRule:
     cooldown_minutes: int
     enabled: bool
     created_at: datetime
+    alert_mode: str = "static"        # static | ml | both
+    ml_score_threshold: float = 0.7   # used when alert_mode in ('ml', 'both')
 
 
 @dataclass
@@ -158,6 +161,7 @@ class ClickHouseWriter:
             rule.threshold, rule.severity, rule.cooldown_minutes,
             int(rule.enabled), rule.created_at,
             int(_time.time() * 1000),
+            rule.alert_mode, rule.ml_score_threshold,
         ]]
         await self._client.insert("alert_rules", data=data, column_names=_RULE_INSERT_COLUMNS)
 
@@ -360,7 +364,8 @@ class ClickHouseReader:
     async def get_alert_rules(self, server_id: str) -> list[AlertRule]:
         result = await self._client.query(
             "SELECT rule_id, server_id, metric_name, operator, threshold,"
-            "       severity, cooldown_minutes, enabled, created_at"
+            "       severity, cooldown_minutes, enabled, created_at,"
+            "       alert_mode, ml_score_threshold"
             " FROM alert_rules FINAL"
             " WHERE server_id = {server_id:String} AND enabled = 1"
             " ORDER BY created_at",
@@ -371,9 +376,25 @@ class ClickHouseReader:
                 rule_id=r[0], server_id=r[1], metric_name=r[2], operator=r[3],
                 threshold=r[4], severity=r[5], cooldown_minutes=r[6],
                 enabled=bool(r[7]), created_at=r[8],
+                alert_mode=r[9] or "static",
+                ml_score_threshold=float(r[10]) if r[10] is not None else 0.7,
             )
             for r in result.result_rows
         ]
+
+    async def get_latest_anomaly_score(self, server_id: str, metric_name: str) -> float | None:
+        """Return the most recent anomaly score for a server/metric pair, or None."""
+        result = await self._client.query(
+            "SELECT score FROM anomaly_scores FINAL"
+            " WHERE server_id = {server_id:String}"
+            "   AND metric_name = {metric_name:String}"
+            "   AND timestamp >= now() - INTERVAL 5 MINUTE"
+            " ORDER BY timestamp DESC LIMIT 1",
+            parameters={"server_id": server_id, "metric_name": metric_name},
+        )
+        if not result.result_rows:
+            return None
+        return float(result.result_rows[0][0])
 
     async def get_alert_events(self, server_id: str, limit: int = 100) -> list[AlertEvent]:
         result = await self._client.query(

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -11,6 +11,7 @@ from app.config import settings
 from app.feature_engineering import run_feature_pipeline
 from app.ml.anomaly_detector import run_anomaly_detector
 from app.ml.model_store import ModelStore
+from app.ml.river_detector import RiverDetector, run_river_detector
 from app.alerts import router as alerts_router
 from app.auth import get_current_user
 from app.auth import router as auth_router
@@ -46,6 +47,11 @@ async def lifespan(app: FastAPI):
     store.load_all()
     app.state.model_store = store
 
+    # Initialise River online detector and load persisted state.
+    river = RiverDetector(Path(settings.ml_models_dir))
+    river.load_all()
+    app.state.river_detector = river
+
     # Start background consumers.
     metrics_task = asyncio.create_task(run_consumer(writer), name="metrics-consumer")
     heartbeat_task = asyncio.create_task(run_heartbeat_consumer(), name="heartbeat-consumer")
@@ -53,12 +59,13 @@ async def lifespan(app: FastAPI):
     alert_task = asyncio.create_task(run_alert_evaluator(reader, writer), name="alert-evaluator")
     feature_task = asyncio.create_task(run_feature_pipeline(reader, writer), name="feature-pipeline")
     detector_task = asyncio.create_task(run_anomaly_detector(reader, writer, store), name="anomaly-detector")
-    logger.info("app: all consumers, alert evaluator, feature pipeline and anomaly detector started")
+    river_task = asyncio.create_task(run_river_detector(reader, writer, river), name="river-detector")
+    logger.info("app: all consumers, evaluator, feature pipeline, IF detector and River detector started")
 
     yield
 
     # Graceful shutdown.
-    for task in (metrics_task, heartbeat_task, log_task, alert_task, feature_task, detector_task):
+    for task in (metrics_task, heartbeat_task, log_task, alert_task, feature_task, detector_task, river_task):
         task.cancel()
         try:
             await task

--- a/api/app/metrics.py
+++ b/api/app/metrics.py
@@ -40,6 +40,18 @@ class MetricNamesResponse(BaseModel):
     metrics: list[str]
 
 
+class AnomalyScorePoint(BaseModel):
+    timestamp: str
+    score: float
+
+
+class AnomalyScoresResponse(BaseModel):
+    server_id: str
+    metric: str
+    minutes: int
+    data: list[AnomalyScorePoint]
+
+
 # ── Dependency ────────────────────────────────────────────────────────────────
 
 def get_reader(request: Request) -> ClickHouseReader:
@@ -89,4 +101,25 @@ async def get_metric_series(
             DataPoint(timestamp=_utc_iso(p.timestamp), value=p.value)
             for p in points
         ],
+    )
+
+
+@router.get("/{server_id}/{metric_name}/anomaly-scores", response_model=AnomalyScoresResponse)
+async def get_anomaly_scores(
+    server_id: str,
+    metric_name: str,
+    minutes: int = Query(
+        default=settings.metrics_query_default_minutes,
+        ge=1,
+        le=settings.metrics_query_max_minutes,
+    ),
+    reader: ClickHouseReader = Depends(get_reader),
+):
+    """Return anomaly scores for a specific server and metric over the last N minutes."""
+    rows = await reader.get_anomaly_scores(server_id, metric_name, minutes)
+    return AnomalyScoresResponse(
+        server_id=server_id,
+        metric=metric_name,
+        minutes=minutes,
+        data=[AnomalyScorePoint(timestamp=_utc_iso(r[0]), score=r[1]) for r in rows],
     )

--- a/api/app/ml/river_detector.py
+++ b/api/app/ml/river_detector.py
@@ -1,0 +1,169 @@
+"""
+River online ML integration — issue #25.
+
+Runs HalfSpaceTrees (streaming anomaly detector) alongside Isolation Forest.
+River updates its model incrementally with each new data point — no batch retraining.
+
+Feature vector used (simpler than IF — no rolling stats needed, River learns them online):
+  value, hour_sin, hour_cos, day_of_week, is_weekend
+
+Background task polls for new metric data every 60 seconds, scores each point,
+updates the model, and persists scores to anomaly_scores with model_version='river'.
+River model state is saved to disk after every 500 updates.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+import pickle
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import redis.asyncio as aioredis
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+_POLL_INTERVAL_SECONDS = 60
+_SAVE_EVERY_N_UPDATES = 500
+_WATERMARK_KEY = "maestro:river_watermarks"
+_MODEL_VERSION = "river"
+
+
+def _time_features(ts: datetime) -> dict[str, float]:
+    hour_frac = ts.hour + ts.minute / 60 + ts.second / 3600
+    radians = 2 * math.pi * hour_frac / 24
+    return {
+        "hour_sin": math.sin(radians),
+        "hour_cos": math.cos(radians),
+        "day_of_week": float(ts.weekday()),
+        "is_weekend": 1.0 if ts.weekday() >= 5 else 0.0,
+    }
+
+
+class RiverDetector:
+    """Per-(server, metric) HalfSpaceTrees online anomaly detector."""
+
+    def __init__(self, models_dir: Path) -> None:
+        self._dir = models_dir / "river"
+        self._models: dict[tuple[str, str], object] = {}
+        self._update_counts: dict[tuple[str, str], int] = {}
+
+    def _model_path(self, server_id: str, metric_name: str) -> Path:
+        return self._dir / server_id / f"{metric_name}.river.pkl"
+
+    def load_all(self) -> int:
+        if not self._dir.exists():
+            return 0
+        count = 0
+        for pkl in self._dir.glob("*/*.river.pkl"):
+            try:
+                self._models[pkl.parent.name, pkl.stem.replace(".river", "")] = (
+                    pickle.loads(pkl.read_bytes())
+                )
+                count += 1
+            except Exception as exc:
+                logger.warning("river: failed to load %s: %s", pkl, exc)
+        logger.info("river: loaded %d model(s)", count)
+        return count
+
+    def _get_or_create(self, server_id: str, metric_name: str):
+        key = (server_id, metric_name)
+        if key not in self._models:
+            from river import anomaly
+            self._models[key] = anomaly.HalfSpaceTrees(seed=42)
+            self._update_counts[key] = 0
+        return self._models[key]
+
+    def update_and_score(self, server_id: str, metric_name: str, value: float, ts: datetime) -> float:
+        """Score one point then learn from it. Returns normalised score in [0, 1]."""
+        model = self._get_or_create(server_id, metric_name)
+        features = {"value": value, **_time_features(ts)}
+        raw_score = model.score_one(features)
+        model.learn_one(features)
+        key = (server_id, metric_name)
+        self._update_counts[key] = self._update_counts.get(key, 0) + 1
+        return float(min(1.0, max(0.0, raw_score)))
+
+    def save_if_due(self, server_id: str, metric_name: str) -> None:
+        key = (server_id, metric_name)
+        if self._update_counts.get(key, 0) % _SAVE_EVERY_N_UPDATES == 0:
+            self._persist(server_id, metric_name)
+
+    def _persist(self, server_id: str, metric_name: str) -> None:
+        key = (server_id, metric_name)
+        model = self._models.get(key)
+        if model is None:
+            return
+        path = self._model_path(server_id, metric_name)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            path.write_bytes(pickle.dumps(model))
+        except Exception as exc:
+            logger.warning("river: failed to save %s/%s: %s", server_id, metric_name, exc)
+
+    def save_all(self) -> None:
+        for server_id, metric_name in list(self._models):
+            self._persist(server_id, metric_name)
+
+
+async def run_river_detector(reader, writer, detector: RiverDetector) -> None:
+    """
+    Background task: poll for new metric data every 60s, score with River,
+    persist scores to anomaly_scores with model_version='river'.
+    """
+    redis = aioredis.from_url(settings.redis_url, decode_responses=True)
+    logger.info("river-detector: starting")
+    try:
+        while True:
+            try:
+                servers = await reader.get_known_server_ids()
+                for server_id in servers:
+                    metrics = await reader.get_metric_names(server_id)
+                    for metric_name in metrics:
+                        await _process_metric(reader, writer, redis, detector, server_id, metric_name)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.error("river-detector: error: %s", exc, exc_info=True)
+            await asyncio.sleep(_POLL_INTERVAL_SECONDS)
+    except asyncio.CancelledError:
+        detector.save_all()
+        logger.info("river-detector: saved models, shutting down")
+    finally:
+        await redis.aclose()
+
+
+async def _process_metric(reader, writer, redis, detector: RiverDetector,
+                           server_id: str, metric_name: str) -> None:
+    wm_key = f"{server_id}:{metric_name}"
+    watermark_str = await redis.hget(_WATERMARK_KEY, wm_key)
+
+    since = (
+        datetime.fromisoformat(watermark_str)
+        if watermark_str
+        else datetime.now(tz=timezone.utc) - timedelta(hours=1)
+    )
+
+    rows = await reader.get_metrics_range(server_id, metric_name, since)
+    if not rows:
+        return
+
+    timestamps, scores = [], []
+    latest_ts = since
+    for ts, value in rows:
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        score = detector.update_and_score(server_id, metric_name, value, ts)
+        timestamps.append(ts)
+        scores.append(score)
+        if ts > latest_ts:
+            latest_ts = ts
+
+    await writer.insert_anomaly_scores(server_id, metric_name, timestamps, scores, _MODEL_VERSION)
+    detector.save_if_due(server_id, metric_name)
+
+    if latest_ts > since:
+        await redis.hset(_WATERMARK_KEY, wm_key, latest_ts.isoformat())

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -13,3 +13,4 @@ pandas
 numpy
 scikit-learn
 joblib
+river

--- a/api/tests/test_river_detector.py
+++ b/api/tests/test_river_detector.py
@@ -1,0 +1,69 @@
+"""Unit tests for the River online anomaly detector."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from app.ml.river_detector import RiverDetector
+
+
+def _ts(hour: int = 10) -> datetime:
+    return datetime(2026, 5, 12, hour, 0, 0, tzinfo=timezone.utc)
+
+
+class TestRiverDetector:
+    def test_score_in_unit_range(self, tmp_path):
+        det = RiverDetector(tmp_path)
+        score = det.update_and_score("srv", "cpu", 50.0, _ts())
+        assert 0.0 <= score <= 1.0
+
+    def test_score_does_not_raise_on_repeated_calls(self, tmp_path):
+        det = RiverDetector(tmp_path)
+        for i in range(50):
+            score = det.update_and_score("srv", "cpu", float(i % 100), _ts(i % 24))
+            assert 0.0 <= score <= 1.0
+
+    def test_separate_models_per_metric(self, tmp_path):
+        det = RiverDetector(tmp_path)
+        det.update_and_score("srv", "cpu", 50.0, _ts())
+        det.update_and_score("srv", "memory", 70.0, _ts())
+        assert ("srv", "cpu") in det._models
+        assert ("srv", "memory") in det._models
+
+    def test_save_and_load_roundtrip(self, tmp_path):
+        det = RiverDetector(tmp_path)
+        for i in range(20):
+            det.update_and_score("srv", "cpu", float(i), _ts())
+        det.save_all()
+
+        # Verify file exists
+        assert (tmp_path / "river" / "srv" / "cpu.river.pkl").exists()
+
+        # Load in fresh instance
+        det2 = RiverDetector(tmp_path)
+        count = det2.load_all()
+        assert count == 1
+
+        # Should score without error after reload
+        score = det2.update_and_score("srv", "cpu", 50.0, _ts())
+        assert 0.0 <= score <= 1.0
+
+    def test_load_all_empty_dir(self, tmp_path):
+        det = RiverDetector(tmp_path)
+        assert det.load_all() == 0
+
+    def test_anomaly_score_higher_for_extreme_value(self, tmp_path):
+        """After training on normal data, an extreme spike should score higher."""
+        det = RiverDetector(tmp_path)
+        # Train on normal data
+        for i in range(200):
+            det.update_and_score("srv", "cpu", 50.0 + (i % 5), _ts(i % 24))
+
+        # Normal point
+        normal_score = det.update_and_score("srv", "cpu", 52.0, _ts(10))
+        # Extreme spike
+        spike_score = det.update_and_score("srv", "cpu", 9999.0, _ts(10))
+
+        assert spike_score >= normal_score

--- a/frontend/src/components/Alerts.tsx
+++ b/frontend/src/components/Alerts.tsx
@@ -27,6 +27,8 @@ function RuleForm({ serverId, onClose }: { serverId: string; onClose: () => void
     threshold: 80,
     severity: 'warning',
     cooldown_minutes: 5,
+    alert_mode: 'static',
+    ml_score_threshold: 0.7,
   })
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -42,6 +44,7 @@ function RuleForm({ serverId, onClose }: { serverId: string; onClose: () => void
   )
 
   const inputCls = 'bg-brand-slate border border-white/10 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-brand-purple/50 transition-all'
+  const usesML = form.alert_mode === 'ml' || form.alert_mode === 'both'
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
@@ -69,6 +72,14 @@ function RuleForm({ serverId, onClose }: { serverId: string; onClose: () => void
           {METRICS_COMMON.map((m) => <option key={m} value={m} />)}
         </datalist>
 
+        {field('Modo de Detecção',
+          <select value={form.alert_mode} onChange={(e) => setForm({ ...form, alert_mode: e.target.value })} className={inputCls}>
+            <option value="static">Estático (threshold fixo)</option>
+            <option value="ml">ML (score de anomalia)</option>
+            <option value="both">Ambos (estático OU ML)</option>
+          </select>
+        )}
+
         <div className="grid grid-cols-2 gap-3">
           {field('Operador',
             <select value={form.operator} onChange={(e) => setForm({ ...form, operator: e.target.value })} className={inputCls}>
@@ -86,6 +97,21 @@ function RuleForm({ serverId, onClose }: { serverId: string; onClose: () => void
             />
           )}
         </div>
+
+        {usesML && field('Score de Anomalia (0–1)',
+          <div className="flex items-center gap-3">
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.05}
+              value={form.ml_score_threshold}
+              onChange={(e) => setForm({ ...form, ml_score_threshold: parseFloat(e.target.value) })}
+              className="flex-1 accent-brand-purple"
+            />
+            <span className="font-mono text-sm text-slate-200 w-10 text-right">{form.ml_score_threshold?.toFixed(2)}</span>
+          </div>
+        )}
 
         <div className="grid grid-cols-2 gap-3">
           {field('Severidade',
@@ -231,9 +257,17 @@ const Alerts: React.FC<AlertsProps> = ({ setView }) => {
                       <span className={`text-[10px] font-bold uppercase px-2 py-0.5 rounded-full border ${severityBadge(rule.severity)}`}>
                         {rule.severity}
                       </span>
+                      {rule.alert_mode && rule.alert_mode !== 'static' && (
+                        <span className="text-[10px] font-bold uppercase px-2 py-0.5 rounded-full border bg-brand-purple/10 text-brand-purple border-brand-purple/20">
+                          {rule.alert_mode === 'ml' ? 'ML' : 'ML+static'}
+                        </span>
+                      )}
                     </div>
                     <p className="text-[11px] text-slate-500 mt-1">
                       Cooldown {rule.cooldown_minutes}min &bull; Criado {fmt(rule.created_at)}
+                      {rule.alert_mode && rule.alert_mode !== 'static' && (
+                        <> &bull; Score ≥ {rule.ml_score_threshold?.toFixed(2)}</>
+                      )}
                     </p>
                   </div>
                   <button

--- a/frontend/src/components/ServerDashboard.tsx
+++ b/frontend/src/components/ServerDashboard.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import ReactECharts from 'echarts-for-react'
 import * as echarts from 'echarts'
-import { ArrowLeft, RefreshCw } from 'lucide-react'
-import { useMetricNames, useMetricSeries } from '../hooks/useMetrics'
+import { ArrowLeft, RefreshCw, Activity } from 'lucide-react'
+import { useMetricNames, useMetricSeries, useAnomalyScores } from '../hooks/useMetrics'
 import MetricCard from './MetricCard'
 import Layout from './Layout'
 import type { ViewType } from '../App'
@@ -34,11 +34,60 @@ interface MetricChartProps {
   serverId: string
   metric: string
   minutes: number
+  showAnomalies?: boolean
 }
 
-const MetricChart: React.FC<MetricChartProps> = ({ serverId, metric, minutes }) => {
+const MetricChart: React.FC<MetricChartProps> = ({ serverId, metric, minutes, showAnomalies = false }) => {
   const { data, isFetching } = useMetricSeries(serverId, metric, minutes)
+  const { data: anomalyData } = useAnomalyScores(serverId, metric, minutes, showAnomalies)
   const cfg = METRIC_CONFIG[metric] ?? { label: metric, unit: '', color: '#94A3B8' }
+
+  // Build sorted timestamp→value lookup for anomaly scatter positioning
+  const metricLookup = useMemo(() => {
+    const entries = (data?.data ?? []).map(
+      (p) => [new Date(p.timestamp).getTime(), p.value] as [number, number]
+    )
+    return entries.sort((a, b) => a[0] - b[0])
+  }, [data])
+
+  const nearestValue = (ts: string): number | null => {
+    if (!metricLookup.length) return null
+    const t = new Date(ts).getTime()
+    let best = metricLookup[0]
+    for (const entry of metricLookup) {
+      if (Math.abs(entry[0] - t) < Math.abs(best[0] - t)) best = entry
+      if (entry[0] > t + 5 * 60_000) break
+    }
+    return best[1]
+  }
+
+  const anomalyPoints = useMemo(() => {
+    if (!showAnomalies || !anomalyData) return { amber: [], red: [] }
+    const amber: { value: [string, number]; score: number }[] = []
+    const red: { value: [string, number]; score: number }[] = []
+    for (const a of anomalyData.data) {
+      if (a.score < 0.5) continue
+      const v = nearestValue(a.timestamp)
+      if (v === null) continue
+      const point = { value: [a.timestamp, parseFloat(v.toFixed(2))] as [string, number], score: a.score }
+      if (a.score >= 0.8) red.push(point)
+      else amber.push(point)
+    }
+    return { amber, red }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [anomalyData, showAnomalies, metricLookup])
+
+  const scatterTooltip = {
+    trigger: 'item' as const,
+    formatter: (p: any) => {
+      const d = new Date(p.value[0])
+      const t = `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
+      return `${t}<br/>Anomalia: <b>${p.data.score.toFixed(2)}</b>`
+    },
+    backgroundColor: '#1E293B',
+    borderColor: '#EF4444',
+    textStyle: { color: '#F1F5F9', fontSize: 11 },
+  }
 
   const option = {
     backgroundColor: 'transparent',
@@ -48,9 +97,11 @@ const MetricChart: React.FC<MetricChartProps> = ({ serverId, metric, minutes }) 
       borderColor: cfg.color,
       textStyle: { color: '#F1F5F9', fontSize: 11 },
       formatter: (params: any[]) => {
-        const d = new Date(params[0].value[0])
+        const line = params.find((p: any) => p.seriesType === 'line')
+        if (!line) return ''
+        const d = new Date(line.value[0])
         const t = `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
-        return `${t}<br/>${params[0].seriesName}: ${params[0].value[1]}`
+        return `${t}<br/>${line.seriesName}: ${line.value[1]}`
       },
     },
     grid: { left: '3%', right: '4%', bottom: '3%', top: '8%', containLabel: true },
@@ -86,6 +137,28 @@ const MetricChart: React.FC<MetricChartProps> = ({ serverId, metric, minutes }) 
         },
         lineStyle: { width: 2, color: cfg.color },
       },
+      ...(showAnomalies
+        ? [
+            {
+              name: 'Anomalia média',
+              type: 'scatter',
+              data: anomalyPoints.amber,
+              symbolSize: 8,
+              itemStyle: { color: '#F59E0B', borderColor: '#78350F', borderWidth: 1 },
+              tooltip: scatterTooltip,
+              z: 10,
+            },
+            {
+              name: 'Anomalia alta',
+              type: 'scatter',
+              data: anomalyPoints.red,
+              symbolSize: 10,
+              itemStyle: { color: '#EF4444', borderColor: '#7F1D1D', borderWidth: 1 },
+              tooltip: scatterTooltip,
+              z: 11,
+            },
+          ]
+        : []),
     ],
   }
 
@@ -104,6 +177,7 @@ const MetricChart: React.FC<MetricChartProps> = ({ serverId, metric, minutes }) 
 
 const ServerDashboard: React.FC<ServerDashboardProps> = ({ serverId, setView }) => {
   const [minutes, setMinutes] = useState(60)
+  const [showAnomalies, setShowAnomalies] = useState(false)
   const { data: metricNames } = useMetricNames(serverId)
 
   const summaryMetrics = ['cpu_usage_percent', 'memory_usage_percent', 'disk_usage_percent', 'process_count']
@@ -121,20 +195,34 @@ const ServerDashboard: React.FC<ServerDashboardProps> = ({ serverId, setView }) 
             <ArrowLeft className="w-4 h-4" />
             Servidores
           </button>
-          <div className="flex gap-1">
-            {TIME_RANGES.map((r) => (
-              <button
-                key={r.label}
-                onClick={() => setMinutes(r.minutes)}
-                className={`px-3 py-1 text-xs font-mono rounded transition-colors ${
-                  minutes === r.minutes
-                    ? 'bg-brand-purple text-white'
-                    : 'text-slate-400 hover:text-slate-200'
-                }`}
-              >
-                {r.label}
-              </button>
-            ))}
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setShowAnomalies((v) => !v)}
+              title="Exibir pontos de anomalia nos gráficos"
+              className={`flex items-center gap-1.5 px-3 py-1 text-xs font-mono rounded border transition-colors ${
+                showAnomalies
+                  ? 'bg-brand-purple/20 border-brand-purple/50 text-brand-purple'
+                  : 'border-white/10 text-slate-400 hover:text-slate-200'
+              }`}
+            >
+              <Activity className="w-3 h-3" />
+              Anomalias
+            </button>
+            <div className="flex gap-1">
+              {TIME_RANGES.map((r) => (
+                <button
+                  key={r.label}
+                  onClick={() => setMinutes(r.minutes)}
+                  className={`px-3 py-1 text-xs font-mono rounded transition-colors ${
+                    minutes === r.minutes
+                      ? 'bg-brand-purple text-white'
+                      : 'text-slate-400 hover:text-slate-200'
+                  }`}
+                >
+                  {r.label}
+                </button>
+              ))}
+            </div>
           </div>
         </div>
 
@@ -148,7 +236,7 @@ const ServerDashboard: React.FC<ServerDashboardProps> = ({ serverId, setView }) 
         {/* Charts (#15) */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
           {chartMetrics.map((metric) => (
-            <MetricChart key={metric} serverId={serverId} metric={metric} minutes={minutes} />
+            <MetricChart key={metric} serverId={serverId} metric={metric} minutes={minutes} showAnomalies={showAnomalies} />
           ))}
         </div>
       </div>

--- a/frontend/src/hooks/useMetrics.ts
+++ b/frontend/src/hooks/useMetrics.ts
@@ -16,3 +16,11 @@ export const useMetricSeries = (serverId: string, metric: string, minutes: numbe
     enabled: !!serverId && !!metric,
     refetchInterval: 30_000,
   })
+
+export const useAnomalyScores = (serverId: string, metric: string, minutes: number, enabled = true) =>
+  useQuery({
+    queryKey: ['anomaly-scores', serverId, metric, minutes],
+    queryFn: () => metricsApi.anomalyScores(serverId, metric, minutes),
+    enabled: enabled && !!serverId && !!metric,
+    refetchInterval: 60_000,
+  })

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -49,6 +49,10 @@ export const metricsApi = {
     http
       .get<MetricSeries>(`/metrics/${serverId}/${metric}`, { params: { minutes } })
       .then((r) => r.data),
+  anomalyScores: (serverId: string, metric: string, minutes: number): Promise<AnomalyScoresResponse> =>
+    http
+      .get<AnomalyScoresResponse>(`/metrics/${serverId}/${metric}/anomaly-scores`, { params: { minutes } })
+      .then((r) => r.data),
 }
 
 export interface LogFilesResponse {
@@ -147,6 +151,8 @@ export interface AlertRule {
   severity: 'warning' | 'critical'
   cooldown_minutes: number
   created_at: string
+  alert_mode: string
+  ml_score_threshold: number
 }
 
 export interface AlertRuleIn {
@@ -155,6 +161,20 @@ export interface AlertRuleIn {
   threshold: number
   severity: 'warning' | 'critical'
   cooldown_minutes: number
+  alert_mode?: string
+  ml_score_threshold?: number
+}
+
+export interface AnomalyScore {
+  timestamp: string
+  score: number
+}
+
+export interface AnomalyScoresResponse {
+  server_id: string
+  metric: string
+  minutes: number
+  data: AnomalyScore[]
 }
 
 export interface AlertEventsResponse {

--- a/migrations/007_alter_alert_rules_ml.sql
+++ b/migrations/007_alter_alert_rules_ml.sql
@@ -1,0 +1,13 @@
+-- Migration: 007_alter_alert_rules_ml
+-- Description: Add ML alerting fields to alert_rules table (Phase 3, issue #23).
+--
+-- alert_mode controls which evaluation strategy fires the alert:
+--   'static' — existing threshold-based evaluation only (default, backwards-compatible)
+--   'ml'     — fires when anomaly score > ml_score_threshold; falls back to static if no model
+--   'both'   — either static OR ml breach fires the alert
+--
+-- ml_score_threshold is only used when alert_mode is 'ml' or 'both'.
+-- Default 0.7 means the model must be 70% confident the point is anomalous.
+
+ALTER TABLE maestro.alert_rules ADD COLUMN IF NOT EXISTS alert_mode LowCardinality(String) DEFAULT 'static';
+ALTER TABLE maestro.alert_rules ADD COLUMN IF NOT EXISTS ml_score_threshold Float64 DEFAULT 0.7;


### PR DESCRIPTION
## Summary

- **#23 Dynamic alert thresholds**: `alert_mode` field on alert rules (static / ml / both); evaluator checks anomaly score from ClickHouse before firing; fallback to static if no ML model available yet
- **#25 River online ML**: `RiverDetector` with HalfSpaceTrees per (server, metric); polls every 60s; Redis watermarks for deduplication; saves state every 500 updates; scores stored in `anomaly_scores` with `model_version='river'`
- **#26 Anomaly visualization**: toggle button in ServerDashboard header overlays amber (0.5–0.79) and red (≥0.80) scatter points on metric charts; `useAnomalyScores` hook + `metricsApi.anomalyScores()` 
- **Migration 007**: `ALTER TABLE alert_rules ADD COLUMN alert_mode, ml_score_threshold`
- **Frontend Alerts**: mode selector + score threshold slider in rule creation form; ML/ML+static badge on rule cards

## Components Changed

- [x] API (Python)
- [x] Frontend (React)
- [x] Infra / Config

## Test Plan

- [x] Python: 38 tests passing (16 feature engineering + 16 anomaly detector + 6 River)
- [x] Frontend: `tsc -b --noEmit` passing (0 errors)
- [ ] Manual: create rule with mode=ML, verify evaluator uses score; toggle Anomalias button in dashboard
- [ ] Server: migration 007 runs on deploy, River detector starts alongside IF detector

## Notes

River scores and IF scores share the same `anomaly_scores` table via `model_version` field. River overwrites IF for the same timestamp via ReplacingMergeTree — intentional, River is real-time while IF is batch baseline.

Closes #23
Closes #25
Closes #26