### PR TITLE
fix(security): restore 'top target' stat — handle Invalid user log pattern

### DIFF
--- a/api/app/clickhouse.py
+++ b/api/app/clickhouse.py
@@ -341,12 +341,18 @@ class ClickHouseReader:
                 parameters={"s": server_id},
             ),
             self._client.query(
-                "SELECT extract(line, 'for (?:invalid user )?(\\\\S+) from') AS u, count() AS cnt"
+                # coalesce handles both log patterns:
+                #   'Failed password for [invalid user] <user> from' → first extract
+                #   'Invalid user <user> from'                        → second extract
+                "SELECT coalesce("
+                "    nullIf(extract(line, 'for (?:invalid user )?(\\\\S+) from'), ''),"
+                "    nullIf(extract(line, 'Invalid user (\\\\S+) from'), '')"
+                ") AS u, count() AS cnt"
                 " FROM logs"
                 " WHERE server_id = {s:String} AND log_file = 'auth.log'"
                 "   AND timestamp >= now() - INTERVAL 24 HOUR"
                 "   AND match(line, 'Failed password|Invalid user')"
-                " GROUP BY u ORDER BY cnt DESC LIMIT 1",
+                " GROUP BY u HAVING u != '' ORDER BY cnt DESC LIMIT 1",
                 parameters={"s": server_id},
             ),
         )
@@ -354,7 +360,7 @@ class ClickHouseReader:
             attempts_1h=q_1h.result_rows[0][0] if q_1h.result_rows else 0,
             attempts_24h=q_24h.result_rows[0][0] if q_24h.result_rows else 0,
             unique_ips_24h=q_ips.result_rows[0][0] if q_ips.result_rows else 0,
-            top_target=q_top.result_rows[0][0] if q_top.result_rows else None,
+            top_target=q_top.result_rows[0][0] or None if q_top.result_rows else None,
         )
 
     async def get_alert_rules(self, server_id: str) -> list[AlertRule]:


### PR DESCRIPTION
## Summary

- `get_ssh_stats` `top_target` query used `extract(line, 'for (?:invalid user )?(\S+) from')` which only captures usernames from **Failed password** lines
- **Invalid user** lines (`Invalid user root from 1.2.3.4`) have no `for` prefix, so `extract()` returns `''`
- When the majority of brute-force attempts use the `Invalid user` pattern (the common case), `top_target` became an empty string — visually blank in the Security dashboard stat card

## Fix

- `coalesce(nullIf(extract(...first pattern...), ''), nullIf(extract(...second pattern...), ''))` covers both auth.log variants
- `HAVING u != ''` filters out rows where neither pattern matched
- `or None` guard in Python prevents stray `''` from reaching the API

## Components Changed

- [x] API (Python)

## Test Plan

- [x] Verified query logic manually against both log line patterns
- [ ] Live: Security view → "Usuário mais visado" card shows a username again

Closes — (no issue, direct fix)