### PR TITLE
feat(v2-sprint-b): health snapshot, security V2, alert patterns, i18n, primitives

### DIFF
--- a/api/app/alerts.py
+++ b/api/app/alerts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import time
 from datetime import datetime, timezone
 from uuid import UUID, uuid4
@@ -200,3 +201,73 @@ def _rule_out(r: AlertRule) -> AlertRuleOut:
         alert_mode=r.alert_mode,
         ml_score_threshold=r.ml_score_threshold,
     )
+
+
+# ── Rule patterns (V2) ────────────────────────────────────────────────────────
+
+class RulePattern(BaseModel):
+    rule_id: str
+    fires7d: int
+    last_fire: str | None
+    peak_window: str
+    current_value: float | None
+    state: str   # "dormant" | "quiet" | "active" | "firing"
+
+
+class RulePatternsResponse(BaseModel):
+    server_id: str
+    patterns: list[RulePattern]
+
+
+@router.get("/{server_id}/rule-patterns", response_model=RulePatternsResponse)
+async def get_rule_patterns(server_id: str, request: Request) -> RulePatternsResponse:
+    reader: ClickHouseReader = request.app.state.ch_reader
+
+    rules, raw_patterns = await asyncio.gather(
+        reader.get_alert_rules(server_id),
+        reader.get_alert_rule_patterns(server_id),
+    )
+
+    # Fetch current values for each rule's metric in parallel
+    current_values = await asyncio.gather(
+        *[reader.get_latest_metric_value(server_id, r.metric_name) for r in rules]
+    )
+
+    # Determine which rules are currently FIRING (open event in last 5 min)
+    events = await reader.get_alert_events(server_id, limit=50)
+    firing_rules = {str(e.rule_id) for e in events if e.state == "FIRING"}
+
+    patterns: list[RulePattern] = []
+    for rule, cur_val in zip(rules, current_values):
+        rid = str(rule.rule_id)
+        p = raw_patterns.get(rid, {})
+        fires7d = p.get("fires7d", 0)
+
+        if rid in firing_rules:
+            state = "firing"
+        elif fires7d == 0:
+            state = "dormant"
+        elif p.get("last_fire") and _is_recent(p["last_fire"]):
+            state = "active"
+        else:
+            state = "quiet"
+
+        patterns.append(RulePattern(
+            rule_id=rid,
+            fires7d=fires7d,
+            last_fire=p.get("last_fire"),
+            peak_window=p.get("peak_window", "—"),
+            current_value=cur_val,
+            state=state,
+        ))
+    return RulePatternsResponse(server_id=server_id, patterns=patterns)
+
+
+def _is_recent(iso: str) -> bool:
+    """True if ISO timestamp is within the last 24 hours."""
+    try:
+        from datetime import datetime, timezone
+        dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+        return (datetime.now(timezone.utc) - dt).total_seconds() < 86400
+    except Exception:
+        return False

--- a/api/app/clickhouse.py
+++ b/api/app/clickhouse.py
@@ -235,6 +235,19 @@ class ClickHouseWriter:
             await self._client.close()
 
 
+# ── Peak window helper ─────────────────────────────────────────────────────────
+
+def _peak_window(fire_hours: list[int]) -> str:
+    """Given a list of firing hours, return the most common 2h window or '—'."""
+    if not fire_hours:
+        return "—"
+    counts: dict[int, int] = {}
+    for h in fire_hours:
+        counts[h] = counts.get(h, 0) + 1
+    peak = max(counts, key=lambda h: counts[h])
+    return f"{peak:02d}–{(peak + 1) % 24:02d}h"
+
+
 # ── Reader ────────────────────────────────────────────────────────────────────
 
 class ClickHouseReader:
@@ -530,6 +543,140 @@ class ClickHouseReader:
             parameters={"server_id": server_id, "metric_name": metric_name, "minutes": minutes},
         )
         return [(row[0], float(row[1])) for row in result.result_rows]
+
+    # ── V2 health snapshot helpers ────────────────────────────────────────────
+
+    async def get_metric_baseline_7d(self, server_id: str, metric_name: str) -> float | None:
+        result = await self._client.query(
+            "SELECT round(avg(value), 1) FROM metrics"
+            " WHERE server_id = {server_id:String}"
+            "   AND metric_name = {metric_name:String}"
+            "   AND timestamp >= now() - INTERVAL 7 DAY",
+            parameters={"server_id": server_id, "metric_name": metric_name},
+        )
+        if not result.result_rows or result.result_rows[0][0] is None:
+            return None
+        return float(result.result_rows[0][0])
+
+    async def get_metric_sparkline(
+        self, server_id: str, metric_name: str, points: int = 30
+    ) -> list[float]:
+        """Return ~points evenly-sampled avg values over the last 60 minutes."""
+        bucket = max(1, 60 // points)
+        result = await self._client.query(
+            f"SELECT round(avg(value), 1)"
+            " FROM metrics"
+            " WHERE server_id = {server_id:String}"
+            "   AND metric_name = {metric_name:String}"
+            "   AND timestamp >= now() - INTERVAL 60 MINUTE"
+            f" GROUP BY toStartOfInterval(timestamp, INTERVAL {bucket} MINUTE)"
+            f" ORDER BY toStartOfInterval(timestamp, INTERVAL {bucket} MINUTE)",
+            parameters={"server_id": server_id, "metric_name": metric_name},
+        )
+        return [round(float(r[0]), 1) for r in result.result_rows]
+
+    async def get_anomaly_count_6h(self, server_id: str) -> int:
+        result = await self._client.query(
+            "SELECT count() FROM anomaly_scores FINAL"
+            " WHERE server_id = {server_id:String}"
+            "   AND timestamp >= now() - INTERVAL 6 HOUR"
+            "   AND score >= 0.5",
+            parameters={"server_id": server_id},
+        )
+        return int(result.result_rows[0][0]) if result.result_rows else 0
+
+    async def get_attack_by_hour(self, server_id: str) -> list[dict]:
+        result = await self._client.query(
+            "SELECT toHour(timestamp) AS h, count() AS cnt"
+            " FROM logs"
+            " WHERE server_id = {s:String}"
+            "   AND log_file = 'auth.log'"
+            "   AND timestamp >= toStartOfDay(now())"
+            "   AND match(line, 'Failed password|Invalid user')"
+            " GROUP BY h ORDER BY h",
+            parameters={"s": server_id},
+        )
+        counts = {r[0]: r[1] for r in result.result_rows}
+        return [{"hour": h, "count": counts.get(h, 0)} for h in range(24)]
+
+    async def get_ssh_baseline_7d(self, server_id: str) -> float:
+        result = await self._client.query(
+            "SELECT avg(daily_count) FROM ("
+            "  SELECT toStartOfDay(timestamp) AS day, count() AS daily_count"
+            "  FROM logs"
+            "  WHERE server_id = {s:String}"
+            "    AND log_file = 'auth.log'"
+            "    AND timestamp >= now() - INTERVAL 7 DAY"
+            "    AND match(line, 'Failed password|Invalid user')"
+            "  GROUP BY day"
+            ")",
+            parameters={"s": server_id},
+        )
+        if not result.result_rows or result.result_rows[0][0] is None:
+            return 0.0
+        return float(result.result_rows[0][0])
+
+    async def get_attackers_grouped(self, server_id: str) -> list[dict]:
+        result = await self._client.query(
+            "SELECT"
+            "  extract(line, 'from (\\\\S+) port') AS ip,"
+            "  count() AS attempts,"
+            "  groupUniqArray(coalesce("
+            "    nullIf(extract(line, 'for (?:invalid user )?(\\\\S+) from'), ''),"
+            "    nullIf(extract(line, 'Invalid user (\\\\S+) from'), '')"
+            "  )) AS users,"
+            "  max(timestamp) AS last_seen"
+            " FROM logs"
+            " WHERE server_id = {s:String}"
+            "   AND log_file = 'auth.log'"
+            "   AND timestamp >= now() - INTERVAL 24 HOUR"
+            "   AND match(line, 'Failed password|Invalid user')"
+            " GROUP BY ip HAVING ip != ''"
+            " ORDER BY attempts DESC LIMIT 20",
+            parameters={"s": server_id},
+        )
+        now = datetime.now(timezone.utc)
+        rows = []
+        for r in result.result_rows:
+            last_seen_dt = r[3]
+            if hasattr(last_seen_dt, "tzinfo") and last_seen_dt.tzinfo is None:
+                last_seen_dt = last_seen_dt.replace(tzinfo=timezone.utc)
+            elapsed_s = (now - last_seen_dt).total_seconds()
+            rows.append({
+                "ip": r[0],
+                "attempts": r[1],
+                "users": [u for u in r[2] if u],
+                "last_seen": last_seen_dt.isoformat().replace("+00:00", "Z"),
+                "blocked": elapsed_s > 1800,
+            })
+        return rows
+
+    async def get_alert_rule_patterns(self, server_id: str) -> dict[str, dict]:
+        result = await self._client.query(
+            "SELECT rule_id, count() AS fires7d,"
+            "       max(triggered_at) AS last_fire,"
+            "       groupArray(toHour(triggered_at)) AS fire_hours"
+            " FROM alert_events"
+            " WHERE server_id = {s:String}"
+            "   AND triggered_at >= now() - INTERVAL 7 DAY"
+            "   AND state = 'FIRING'"
+            " GROUP BY rule_id",
+            parameters={"s": server_id},
+        )
+        patterns: dict[str, dict] = {}
+        for r in result.result_rows:
+            rule_id = str(r[0])
+            fires7d = int(r[1])
+            last_fire_dt = r[2]
+            fire_hours: list[int] = r[3]
+            if hasattr(last_fire_dt, "tzinfo") and last_fire_dt.tzinfo is None:
+                last_fire_dt = last_fire_dt.replace(tzinfo=timezone.utc)
+            patterns[rule_id] = {
+                "fires7d": fires7d,
+                "last_fire": last_fire_dt.isoformat().replace("+00:00", "Z") if last_fire_dt else None,
+                "peak_window": _peak_window(fire_hours),
+            }
+        return patterns
 
     async def close(self) -> None:
         if self._client is not None:

--- a/api/app/security.py
+++ b/api/app/security.py
@@ -98,3 +98,60 @@ async def _fetch(reader: ClickHouseReader, server_id: str):
         reader.get_ssh_stats(server_id),
     )
     return rows_result, stats
+
+
+# ── V2 security endpoints ──────────────────────────────────────────────────────
+
+class AttackerOut(BaseModel):
+    ip: str
+    attempts: int
+    users: list[str]
+    last_seen: str
+    blocked: bool
+
+
+class AttackHourBucket(BaseModel):
+    hour: int
+    count: int
+
+
+class AttackersResponse(BaseModel):
+    server_id: str
+    attackers: list[AttackerOut]
+
+
+class AttackByHourResponse(BaseModel):
+    server_id: str
+    hours: list[AttackHourBucket]
+
+
+class SshBaselineResponse(BaseModel):
+    server_id: str
+    avg_daily: float
+
+
+@router.get("/{server_id}/attackers", response_model=AttackersResponse)
+async def get_attackers(server_id: str, request: Request) -> AttackersResponse:
+    reader: ClickHouseReader = request.app.state.ch_reader
+    rows = await reader.get_attackers_grouped(server_id)
+    return AttackersResponse(
+        server_id=server_id,
+        attackers=[AttackerOut(**r) for r in rows],
+    )
+
+
+@router.get("/{server_id}/attack-by-hour", response_model=AttackByHourResponse)
+async def get_attack_by_hour(server_id: str, request: Request) -> AttackByHourResponse:
+    reader: ClickHouseReader = request.app.state.ch_reader
+    buckets = await reader.get_attack_by_hour(server_id)
+    return AttackByHourResponse(
+        server_id=server_id,
+        hours=[AttackHourBucket(**b) for b in buckets],
+    )
+
+
+@router.get("/{server_id}/ssh-baseline", response_model=SshBaselineResponse)
+async def get_ssh_baseline(server_id: str, request: Request) -> SshBaselineResponse:
+    reader: ClickHouseReader = request.app.state.ch_reader
+    avg = await reader.get_ssh_baseline_7d(server_id)
+    return SshBaselineResponse(server_id=server_id, avg_daily=avg)

--- a/api/app/servers.py
+++ b/api/app/servers.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from datetime import datetime, timezone
 
 import redis.asyncio as aioredis
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
+from app.clickhouse import ClickHouseReader
 from app.config import settings
 
 logger = logging.getLogger(__name__)
@@ -71,3 +73,171 @@ async def get_server_status(server_id: str, redis: aioredis.Redis = Depends(get_
     if raw is None:
         raise HTTPException(status_code=404, detail=f"Server '{server_id}' not found")
     return _build_server_status(server_id, raw)
+
+
+# ── Health snapshot ───────────────────────────────────────────────────────────
+
+class MetricHealth(BaseModel):
+    value: float | None
+    baseline: float | None
+    threshold: float
+    trend: str               # "up" | "down" | "stable"
+    spark: list[float]
+    projection: str | None   # e.g. "90% in ~2h" — only for memory trending up
+
+
+class CriticalService(BaseModel):
+    name: str
+    ok: bool
+
+
+class ServerHealthSnapshot(BaseModel):
+    server_id: str
+    state: str               # "ok" | "attention" | "critical" | "quiet"
+    cpu: MetricHealth
+    memory: MetricHealth
+    disk: MetricHealth
+    anomalies6h: int
+    critical_services: list[CriticalService]
+    headline: str
+
+
+_THRESHOLDS = {
+    "cpu_usage_percent":    80.0,
+    "memory_usage_percent": 90.0,
+    "disk_usage_percent":   95.0,
+}
+
+
+def _trend(spark: list[float]) -> str:
+    if len(spark) < 4:
+        return "stable"
+    half = len(spark) // 2
+    first = sum(spark[:half]) / half
+    second = sum(spark[half:]) / (len(spark) - half)
+    diff = (second - first) / max(first, 0.1)
+    if diff > 0.03:
+        return "up"
+    if diff < -0.03:
+        return "down"
+    return "stable"
+
+
+def _projection(current: float | None, spark: list[float], threshold: float) -> str | None:
+    if current is None or len(spark) < 5:
+        return None
+    rate_per_hour = spark[-1] - spark[0]
+    if rate_per_hour < 0.5:
+        return None
+    hours = (threshold - current) / rate_per_hour
+    if 0 < hours < 24:
+        return f"{threshold:.0f}% in ~{round(hours)}h"
+    return None
+
+
+def _health_state(
+    cpu_val: float | None,
+    mem_val: float | None,
+    disk_val: float | None,
+    mem_trend: str,
+    mem_proj: str | None,
+) -> str:
+    if cpu_val is None and mem_val is None:
+        return "critical"
+    if (cpu_val and cpu_val >= 80) or (mem_val and mem_val >= 90) or (disk_val and disk_val >= 95):
+        return "critical"
+    if mem_trend == "up" and mem_proj:
+        return "attention"
+    if (cpu_val and cpu_val >= 68) or (mem_val and mem_val >= 76) or (disk_val and disk_val >= 80):
+        return "attention"
+    return "ok"
+
+
+def _headline(
+    state: str,
+    cpu_val: float | None,
+    cpu_base: float | None,
+    mem_val: float | None,
+    mem_trend: str,
+    mem_proj: str | None,
+    anomalies6h: int,
+) -> str:
+    if cpu_val is None:
+        return "offline — no metric collection."
+    if mem_trend == "up" and mem_proj:
+        return f"memory rising — projected {mem_proj}"
+    if state == "critical":
+        if cpu_val and cpu_val >= 80:
+            return f"CPU critical at {cpu_val:.0f}%."
+        if mem_val and mem_val >= 90:
+            return f"memory critical at {mem_val:.0f}%."
+    if cpu_base and cpu_val and cpu_val > cpu_base * 1.10:
+        delta = round(cpu_val - cpu_base)
+        return f"CPU {delta}pp above average."
+    if anomalies6h > 0:
+        return f"{anomalies6h} anomal{'ies' if anomalies6h != 1 else 'y'} in the last 6h."
+    return "all within expected range."
+
+
+@router.get("/{server_id}/health-snapshot", response_model=ServerHealthSnapshot)
+async def get_health_snapshot(
+    server_id: str,
+    request: Request,
+    redis: aioredis.Redis = Depends(get_redis),
+) -> ServerHealthSnapshot:
+    reader: ClickHouseReader = request.app.state.ch_reader
+
+    (
+        cpu_val, mem_val, disk_val,
+        cpu_base, mem_base, disk_base,
+        cpu_spark, mem_spark, disk_spark,
+        anomalies6h,
+    ) = await asyncio.gather(
+        reader.get_latest_metric_value(server_id, "cpu_usage_percent"),
+        reader.get_latest_metric_value(server_id, "memory_usage_percent"),
+        reader.get_latest_metric_value(server_id, "disk_usage_percent"),
+        reader.get_metric_baseline_7d(server_id, "cpu_usage_percent"),
+        reader.get_metric_baseline_7d(server_id, "memory_usage_percent"),
+        reader.get_metric_baseline_7d(server_id, "disk_usage_percent"),
+        reader.get_metric_sparkline(server_id, "cpu_usage_percent"),
+        reader.get_metric_sparkline(server_id, "memory_usage_percent"),
+        reader.get_metric_sparkline(server_id, "disk_usage_percent"),
+        reader.get_anomaly_count_6h(server_id),
+    )
+
+    cpu_t  = _trend(cpu_spark)
+    mem_t  = _trend(mem_spark)
+    disk_t = _trend(disk_spark)
+    mem_proj = _projection(mem_val, mem_spark, _THRESHOLDS["memory_usage_percent"])
+    state = _health_state(cpu_val, mem_val, disk_val, mem_t, mem_proj)
+    headline = _headline(state, cpu_val, cpu_base, mem_val, mem_t, mem_proj, anomalies6h)
+
+    # Critical services from Redis heartbeat inventory
+    raw = await redis.hget(settings.heartbeat_state_key, server_id)
+    services: list[CriticalService] = []
+    if raw:
+        data = json.loads(raw)
+        services = [
+            CriticalService(name=e["name"], ok=e.get("status") == "active")
+            for e in data.get("inventory") or []
+        ]
+
+    return ServerHealthSnapshot(
+        server_id=server_id,
+        state=state,
+        cpu=MetricHealth(
+            value=cpu_val, baseline=cpu_base, threshold=_THRESHOLDS["cpu_usage_percent"],
+            trend=cpu_t, spark=cpu_spark, projection=None,
+        ),
+        memory=MetricHealth(
+            value=mem_val, baseline=mem_base, threshold=_THRESHOLDS["memory_usage_percent"],
+            trend=mem_t, spark=mem_spark, projection=mem_proj,
+        ),
+        disk=MetricHealth(
+            value=disk_val, baseline=disk_base, threshold=_THRESHOLDS["disk_usage_percent"],
+            trend=disk_t, spark=disk_spark, projection=None,
+        ),
+        anomalies6h=anomalies6h,
+        critical_services=services,
+        headline=headline,
+    )

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,9 +14,12 @@
         "date-fns": "^4.1.0",
         "echarts": "^6.0.0",
         "echarts-for-react": "^3.0.6",
+        "i18next": "^26.2.0",
+        "i18next-browser-languagedetector": "^8.2.1",
         "lucide-react": "^0.577.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-i18next": "^17.0.8",
         "zustand": "^5.0.11"
       },
       "devDependencies": {
@@ -282,6 +285,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -3099,6 +3111,52 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.2.0.tgz",
+      "integrity": "sha512-zwBHldHdTmwN7r6UNc7lC6GWNN+YYg3DrRSeHR5PRRBf5QnJZcYHrQc0uaU26qZeYxR7iFZD+Y315dPnKP47wA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://www.locize.com/i18next"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.1.tgz",
+      "integrity": "sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3891,6 +3949,33 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.8.tgz",
+      "integrity": "sha512-0ooKbGLU8JXhe1zwpQUWIeXSgLPOfwJmgheWRIUpcoA0CpyabpGhayjdG+/eA5esC1AQ8h2jWpXjJfzQzeDOCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "html-parse-stringify": "^3.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "i18next": ">= 26.2.0",
+        "react": ">= 16.8.0",
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
@@ -4299,7 +4384,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -4379,6 +4464,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -4461,6 +4555,15 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/which": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,9 +16,12 @@
     "date-fns": "^4.1.0",
     "echarts": "^6.0.0",
     "echarts-for-react": "^3.0.6",
+    "i18next": "^26.2.0",
+    "i18next-browser-languagedetector": "^8.2.1",
     "lucide-react": "^0.577.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-i18next": "^17.0.8",
     "zustand": "^5.0.11"
   },
   "devDependencies": {

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import Sidebar from './Sidebar';
 import { Search } from 'lucide-react';
 import type { ViewType } from '../App';
@@ -10,7 +11,15 @@ interface LayoutProps {
     title: string;
 }
 
+const LANGS = [
+    { code: 'en',    label: 'EN' },
+    { code: 'pt-BR', label: 'PT' },
+]
+
 const Layout: React.FC<LayoutProps> = ({ children, currentView, setView, title }) => {
+    const { i18n } = useTranslation()
+    const currentLang = i18n.language.startsWith('pt') ? 'pt-BR' : 'en'
+
     return (
         <div className="flex min-h-screen bg-brand-dark text-slate-100 font-sans selection:bg-brand-neon selection:text-brand-dark">
             <Sidebar currentView={currentView} setView={setView} />
@@ -32,6 +41,22 @@ const Layout: React.FC<LayoutProps> = ({ children, currentView, setView, title }
                                 placeholder="Pesquisar servidores, logs..."
                                 className="bg-brand-slate border border-white/10 rounded-full py-1.5 pl-9 pr-4 text-sm focus:outline-none focus:border-brand-purple/50 w-64 transition-all"
                             />
+                        </div>
+                        {/* Language toggle */}
+                        <div className="flex items-center rounded-md border border-white/10 overflow-hidden">
+                            {LANGS.map((l) => (
+                                <button
+                                    key={l.code}
+                                    onClick={() => i18n.changeLanguage(l.code)}
+                                    className={`px-3 py-1 text-xs font-mono font-semibold transition-colors ${
+                                        currentLang === l.code
+                                            ? 'bg-brand-purple/20 text-brand-purple'
+                                            : 'text-slate-500 hover:text-slate-300'
+                                    }`}
+                                >
+                                    {l.label}
+                                </button>
+                            ))}
                         </div>
                         <div className="flex items-center gap-2">
                             <div className="w-2 h-2 rounded-full bg-brand-neon animate-pulse shadow-[0_0_8px_rgba(57,255,20,0.6)]"></div>

--- a/frontend/src/components/primitives/BaselineDelta.tsx
+++ b/frontend/src/components/primitives/BaselineDelta.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+
+interface BaselineDeltaProps {
+  value: number | null
+  baseline: number | null
+  unit?: string
+  invertColors?: boolean
+}
+
+const BaselineDelta: React.FC<BaselineDeltaProps> = ({
+  value,
+  baseline,
+  unit = '',
+  invertColors = false,
+}) => {
+  if (baseline == null || value == null) return null
+
+  const delta = value - baseline
+  const sign = delta > 0 ? '+' : ''
+  const isBad = invertColors ? delta < 0 : delta > 0
+  const isNeutral = Math.abs(delta) < baseline * 0.05
+
+  const color = isNeutral
+    ? 'var(--color-fg-3, #64748B)'
+    : isBad
+    ? '#F87171'
+    : '#34D399'
+
+  return (
+    <span style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 12, color }}>
+      {sign}{delta.toFixed(unit === 'pp' ? 0 : 1)}{unit}
+    </span>
+  )
+}
+
+export default BaselineDelta

--- a/frontend/src/components/primitives/HealthScore.tsx
+++ b/frontend/src/components/primitives/HealthScore.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+
+export type HealthState = 'ok' | 'attention' | 'critical' | 'quiet'
+
+interface HealthScoreProps {
+  state: HealthState
+  size?: 'sm' | 'md' | 'lg'
+}
+
+const STATE_CONF: Record<HealthState, { fg: string; bg: string; border: string; labelKey: string }> = {
+  ok:        { fg: '#34D399', bg: 'rgba(52,211,153,0.10)',  border: 'rgba(52,211,153,0.30)',  labelKey: 'health.state.ok' },
+  attention: { fg: '#F59E0B', bg: 'rgba(245,158,11,0.10)',  border: 'rgba(245,158,11,0.30)',  labelKey: 'health.state.attention' },
+  critical:  { fg: '#F87171', bg: 'rgba(239,68,68,0.10)',   border: 'rgba(239,68,68,0.30)',   labelKey: 'health.state.critical' },
+  quiet:     { fg: '#94A3B8', bg: 'rgba(148,163,184,0.10)', border: 'rgba(148,163,184,0.30)', labelKey: 'health.state.quiet' },
+}
+
+const HealthScore: React.FC<HealthScoreProps> = ({ state, size = 'md' }) => {
+  const { t } = useTranslation()
+  const conf = STATE_CONF[state] ?? STATE_CONF.quiet
+
+  const padding = size === 'sm' ? '2px 8px' : size === 'lg' ? '6px 14px' : '4px 10px'
+  const fontSize = size === 'sm' ? 10 : size === 'lg' ? 13 : 11
+  const dotSize = size === 'sm' ? 6 : 8
+
+  return (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center', gap: 6,
+      padding, borderRadius: 6,
+      fontFamily: 'var(--font-mono)',
+      fontSize, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.06em',
+      background: conf.bg, color: conf.fg, border: `1px solid ${conf.border}`,
+    }}>
+      <span style={{
+        width: dotSize, height: dotSize,
+        borderRadius: '50%', background: conf.fg,
+        boxShadow: state === 'ok' ? `0 0 6px ${conf.fg}99` : 'none',
+        flexShrink: 0,
+      }} />
+      {t(conf.labelKey)}
+    </span>
+  )
+}
+
+export default HealthScore

--- a/frontend/src/components/primitives/Sparkline.tsx
+++ b/frontend/src/components/primitives/Sparkline.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+
+interface SparklineProps {
+  data: number[]
+  color?: string
+  width?: number
+  height?: number
+  area?: boolean
+  strokeWidth?: number
+  baseline?: number
+}
+
+const Sparkline: React.FC<SparklineProps> = ({
+  data,
+  color = '#39FF14',
+  width = 80,
+  height = 24,
+  area = true,
+  strokeWidth = 1.5,
+  baseline,
+}) => {
+  if (!data || data.length < 2) return <svg width={width} height={height} />
+
+  const min = Math.min(...data, baseline ?? Infinity)
+  const max = Math.max(...data, baseline ?? -Infinity)
+  const range = max - min || 1
+
+  const pts = data.map((v, i) => {
+    const x = (i / (data.length - 1)) * width
+    const y = height - 2 - ((v - min) / range) * (height - 4)
+    return [x, y] as [number, number]
+  })
+
+  const linePath = pts.map((p, i) => (i === 0 ? `M ${p[0]} ${p[1]}` : `L ${p[0]} ${p[1]}`)).join(' ')
+  const areaPath = `${linePath} L ${width} ${height} L 0 ${height} Z`
+  const gid = `spark-${color.replace('#', '')}-${Math.round(Math.random() * 999999)}`
+  const baseY = baseline != null ? height - 2 - ((baseline - min) / range) * (height - 4) : null
+
+  return (
+    <svg width={width} height={height} style={{ display: 'block' }}>
+      {area && (
+        <>
+          <defs>
+            <linearGradient id={gid} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor={color} stopOpacity="0.35" />
+              <stop offset="100%" stopColor={color} stopOpacity="0" />
+            </linearGradient>
+          </defs>
+          <path d={areaPath} fill={`url(#${gid})`} />
+        </>
+      )}
+      {baseY != null && (
+        <line
+          x1="0" x2={width} y1={baseY} y2={baseY}
+          stroke="rgba(255,255,255,0.12)" strokeWidth="1" strokeDasharray="2 2"
+        />
+      )}
+      <path
+        d={linePath} fill="none"
+        stroke={color} strokeWidth={strokeWidth}
+        strokeLinecap="round" strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+export default Sparkline

--- a/frontend/src/components/primitives/TrendBar.tsx
+++ b/frontend/src/components/primitives/TrendBar.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+
+interface TrendBarProps {
+  value: number
+  max?: number
+  threshold?: number
+  baseline?: number
+  color?: string
+  height?: number
+  width?: string | number
+}
+
+const TrendBar: React.FC<TrendBarProps> = ({
+  value,
+  max = 100,
+  threshold,
+  baseline,
+  color = '#39FF14',
+  height = 6,
+  width = '100%',
+}) => {
+  const pct    = Math.min(100, (value / max) * 100)
+  const thrPct = threshold != null ? (threshold / max) * 100 : null
+  const basePct = baseline != null ? (baseline / max) * 100 : null
+
+  return (
+    <div style={{
+      position: 'relative', width, height,
+      background: 'rgba(255,255,255,0.06)',
+      borderRadius: 3, overflow: 'visible',
+    }}>
+      <div style={{
+        position: 'absolute', inset: 0, width: `${pct}%`,
+        background: color, borderRadius: 3,
+        transition: 'width 0.3s ease',
+      }} />
+      {basePct != null && (
+        <div
+          title={`avg ${baseline}`}
+          style={{
+            position: 'absolute', left: `${basePct}%`,
+            top: -2, bottom: -2, width: 1,
+            background: 'rgba(255,255,255,0.40)',
+          }}
+        />
+      )}
+      {thrPct != null && (
+        <div
+          title={`threshold ${threshold}`}
+          style={{
+            position: 'absolute', left: `${thrPct}%`,
+            top: -3, bottom: -3, width: 2,
+            background: '#F87171',
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+export default TrendBar

--- a/frontend/src/components/primitives/index.ts
+++ b/frontend/src/components/primitives/index.ts
@@ -1,0 +1,5 @@
+export { default as Sparkline } from './Sparkline'
+export { default as HealthScore } from './HealthScore'
+export type { HealthState } from './HealthScore'
+export { default as TrendBar } from './TrendBar'
+export { default as BaselineDelta } from './BaselineDelta'

--- a/frontend/src/hooks/useMetrics.ts
+++ b/frontend/src/hooks/useMetrics.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { metricsApi } from '../services/api'
+import { metricsApi, securityApi, alertsApi, serversApi } from '../services/api'
 
 export const useMetricNames = (serverId: string) =>
   useQuery({
@@ -22,5 +22,45 @@ export const useAnomalyScores = (serverId: string, metric: string, minutes: numb
     queryKey: ['anomaly-scores', serverId, metric, minutes],
     queryFn: () => metricsApi.anomalyScores(serverId, metric, minutes),
     enabled: enabled && !!serverId && !!metric,
+    refetchInterval: 60_000,
+  })
+
+export const useHealthSnapshot = (serverId: string, enabled = true) =>
+  useQuery({
+    queryKey: ['health-snapshot', serverId],
+    queryFn: () => serversApi.healthSnapshot(serverId),
+    enabled: enabled && !!serverId,
+    refetchInterval: 30_000,
+  })
+
+export const useAttackers = (serverId: string) =>
+  useQuery({
+    queryKey: ['attackers', serverId],
+    queryFn: () => securityApi.attackers(serverId),
+    enabled: !!serverId,
+    refetchInterval: 60_000,
+  })
+
+export const useAttackByHour = (serverId: string) =>
+  useQuery({
+    queryKey: ['attack-by-hour', serverId],
+    queryFn: () => securityApi.attackByHour(serverId),
+    enabled: !!serverId,
+    refetchInterval: 60_000,
+  })
+
+export const useSshBaseline = (serverId: string) =>
+  useQuery({
+    queryKey: ['ssh-baseline', serverId],
+    queryFn: () => securityApi.sshBaseline(serverId),
+    enabled: !!serverId,
+    staleTime: 300_000,
+  })
+
+export const useRulePatterns = (serverId: string) =>
+  useQuery({
+    queryKey: ['rule-patterns', serverId],
+    queryFn: () => alertsApi.rulePatterns(serverId),
+    enabled: !!serverId,
     refetchInterval: 60_000,
   })

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1,0 +1,28 @@
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+import LanguageDetector from 'i18next-browser-languagedetector'
+
+import enCommon from './locales/en/common.json'
+import ptBRCommon from './locales/pt-BR/common.json'
+
+i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    fallbackLng: 'en',
+    defaultNS: 'common',
+    resources: {
+      en:    { common: enCommon },
+      'pt-BR': { common: ptBRCommon },
+    },
+    detection: {
+      order: ['localStorage', 'navigator'],
+      caches: ['localStorage'],
+      lookupLocalStorage: 'maestro_lang',
+    },
+    interpolation: {
+      escapeValue: false,
+    },
+  })
+
+export default i18n

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -1,0 +1,169 @@
+{
+  "nav": {
+    "dashboard": "Dashboard",
+    "infrastructure": "Infrastructure",
+    "security": "Security",
+    "alerts": "Alerts",
+    "logs": "Logs"
+  },
+  "common": {
+    "loading": "Loading…",
+    "noData": "No data",
+    "viewAll": "VIEW ALL →",
+    "viewDetails": "VIEW DETAILS →",
+    "viewMap": "VIEW MAP →",
+    "viewCharts": "VIEW CHARTS →",
+    "investigate": "INVESTIGATE →",
+    "save": "Save",
+    "delete": "Delete",
+    "newRule": "New Rule",
+    "openServer": "Open server",
+    "focusHere": "FOCUS HERE",
+    "criticalServices": "CRITICAL SERVICES",
+    "events": "EVENTS",
+    "webhook": "Webhook"
+  },
+  "health": {
+    "state": {
+      "ok": "OK",
+      "attention": "Attention",
+      "critical": "Critical",
+      "quiet": "Quiet",
+      "offline": "Offline"
+    },
+    "metrics": {
+      "cpu": "CPU",
+      "memory": "MEMORY",
+      "disk": "DISK",
+      "currentValue": "current value",
+      "threshold": "threshold",
+      "margin": "margin"
+    },
+    "trend": {
+      "up": "rising",
+      "down": "falling",
+      "stable": "stable"
+    },
+    "anomalies6h_one": "{{count}} anomaly / 6h",
+    "anomalies6h_other": "{{count}} anomalies / 6h"
+  },
+  "dashboard": {
+    "fleet": "Fleet — {{count}} servers",
+    "headline": {
+      "critical_one": "{{count}} critical server",
+      "critical_other": "{{count}} critical servers",
+      "attention": "{{ok}} OK · {{count}} with attention",
+      "allGood": "All good."
+    },
+    "incidents": {
+      "title": "Incidents — 24h",
+      "quiet": "Quiet — no incidents",
+      "quietDesc": "No rule fired in the last 24h.",
+      "firingNow_one": "{{count}} firing now",
+      "firingNow_other": "{{count}} firing now"
+    },
+    "anomalies": {
+      "title": "Anomalies — 6h",
+      "detected": "detected in {{count}} server",
+      "detected_other": "detected in {{count}} servers"
+    },
+    "security": {
+      "label": "SECURITY — 24H",
+      "attempts": "{{count}} SSH attempts blocked",
+      "weeklyAvg": "weekly average"
+    },
+    "offline": {
+      "message": "offline for {{time}} — no metric collection"
+    }
+  },
+  "infrastructure": {
+    "title": "Server Map",
+    "subtitle": "Real-time health snapshot — no need to open each server to check its state.",
+    "services_one": "{{count}} service",
+    "services_other": "{{count}} services",
+    "noMetrics": "No metric collection"
+  },
+  "server": {
+    "summary": "SUMMARY",
+    "anomalySummary": "ANOMALY SUMMARY",
+    "tabs": {
+      "health": "Health",
+      "io": "I/O",
+      "processes": "Processes"
+    }
+  },
+  "security": {
+    "title": "Security",
+    "ssh24h": "SSH · 24H",
+    "attempts": "attempts",
+    "weeklyAvg7d": "7d avg",
+    "peakAt": "Peak at",
+    "attackers": {
+      "title": "Attackers — grouped by IP",
+      "ips": "{{count}} IPs",
+      "attempts": "{{count}} attempts",
+      "users": "Targeted users:",
+      "blockedByFail2ban": "blocked by fail2ban",
+      "underObservation": "under observation"
+    },
+    "session": {
+      "title": "Session Summary",
+      "attempts1h": "Attempts / 1h",
+      "attempts24h": "Attempts / 24h",
+      "uniqueIps": "Unique IPs / 24h",
+      "topTarget": "Top targeted user"
+    },
+    "fail2ban": {
+      "title": "fail2ban",
+      "bansLast24h": "{{count}} IPs banned in the last 24h."
+    }
+  },
+  "alerts": {
+    "title": "Alert Center",
+    "activeRules": "{{count}} active rules",
+    "firingNow_one": "{{count}} rule firing now",
+    "firingNow_other": "{{count}} rules firing now",
+    "quiet": "Quiet — no rule firing.",
+    "dormant_one": "{{count}} dormant",
+    "dormant_other": "{{count}} dormant",
+    "rule": {
+      "currentValue": "current value",
+      "margin": "margin",
+      "state": {
+        "active": "ACTIVE",
+        "quiet": "QUIET",
+        "dormant": "DORMANT",
+        "firing": "FIRING"
+      },
+      "stateHint": {
+        "active": "may fire",
+        "quiet": "all within expected",
+        "dormant": "never fired — verify",
+        "firing": "open event"
+      },
+      "firedCount": "Fired {{count}}× in the last 7d",
+      "pattern": "pattern",
+      "lastFire": "last fire",
+      "neverFired": "never fired"
+    },
+    "webhook": {
+      "title": "Notification webhook",
+      "desc": "Called on every FIRING and RESOLVED event. Compatible with Slack Incoming Webhooks.",
+      "placeholder": "https://hooks.slack.com/services/…"
+    },
+    "detection": {
+      "label": "Detection Mode",
+      "static": "Static",
+      "ml": "ML",
+      "both": "Both (ML + Static)",
+      "scoreThreshold": "ML Score Threshold"
+    }
+  },
+  "logs": {
+    "title": "Log Explorer",
+    "liveLabel": "LIVE",
+    "pauseLabel": "PAUSE",
+    "clearLabel": "CLEAR",
+    "noLogs": "No logs yet — select a file above."
+  }
+}

--- a/frontend/src/i18n/locales/pt-BR/common.json
+++ b/frontend/src/i18n/locales/pt-BR/common.json
@@ -1,0 +1,169 @@
+{
+  "nav": {
+    "dashboard": "Dashboard",
+    "infrastructure": "Infraestrutura",
+    "security": "Segurança",
+    "alerts": "Alertas",
+    "logs": "Logs"
+  },
+  "common": {
+    "loading": "Carregando…",
+    "noData": "Sem dados",
+    "viewAll": "VER TUDO →",
+    "viewDetails": "VER DETALHES →",
+    "viewMap": "VER MAPA →",
+    "viewCharts": "VER GRÁFICOS →",
+    "investigate": "INVESTIGAR →",
+    "save": "Salvar",
+    "delete": "Excluir",
+    "newRule": "Nova Regra",
+    "openServer": "Abrir servidor",
+    "focusHere": "FOCO AQUI",
+    "criticalServices": "SERVIÇOS CRÍTICOS",
+    "events": "EVENTOS",
+    "webhook": "Webhook"
+  },
+  "health": {
+    "state": {
+      "ok": "OK",
+      "attention": "Atenção",
+      "critical": "Crítico",
+      "quiet": "Quiet",
+      "offline": "Offline"
+    },
+    "metrics": {
+      "cpu": "CPU",
+      "memory": "MEMÓRIA",
+      "disk": "DISCO",
+      "currentValue": "valor atual",
+      "threshold": "threshold",
+      "margin": "margem"
+    },
+    "trend": {
+      "up": "subindo",
+      "down": "caindo",
+      "stable": "estável"
+    },
+    "anomalies6h_one": "{{count}} anomalia / 6h",
+    "anomalies6h_other": "{{count}} anomalias / 6h"
+  },
+  "dashboard": {
+    "fleet": "Frota — {{count}} servidores",
+    "headline": {
+      "critical_one": "{{count}} servidor crítico",
+      "critical_other": "{{count}} servidores críticos",
+      "attention": "{{ok}} OK · {{count}} com atenção",
+      "allGood": "Tudo certo."
+    },
+    "incidents": {
+      "title": "Incidentes — 24h",
+      "quiet": "Quiet — nenhum incidente",
+      "quietDesc": "Nenhuma regra disparou nas últimas 24h.",
+      "firingNow_one": "{{count}} disparando agora",
+      "firingNow_other": "{{count}} disparando agora"
+    },
+    "anomalies": {
+      "title": "Anomalias — 6h",
+      "detected": "detectada em {{count}} servidor",
+      "detected_other": "detectadas em {{count}} servidores"
+    },
+    "security": {
+      "label": "SEGURANÇA — 24H",
+      "attempts": "{{count}} tentativas SSH bloqueadas",
+      "weeklyAvg": "média semanal"
+    },
+    "offline": {
+      "message": "offline há {{time}} — sem coleta de métricas"
+    }
+  },
+  "infrastructure": {
+    "title": "Mapa de Servidores",
+    "subtitle": "Snapshot de saúde em tempo real — não precisa abrir cada servidor para descobrir o estado.",
+    "services_one": "{{count}} serviço",
+    "services_other": "{{count}} serviços",
+    "noMetrics": "Sem coleta de métricas"
+  },
+  "server": {
+    "summary": "RESUMO",
+    "anomalySummary": "ANOMALIAS",
+    "tabs": {
+      "health": "Saúde",
+      "io": "I/O",
+      "processes": "Processos"
+    }
+  },
+  "security": {
+    "title": "Segurança",
+    "ssh24h": "SSH · 24H",
+    "attempts": "tentativas",
+    "weeklyAvg7d": "média 7d",
+    "peakAt": "Pico em",
+    "attackers": {
+      "title": "Atacantes — agrupados por IP",
+      "ips": "{{count}} IPs",
+      "attempts": "{{count}} tentativas",
+      "users": "Usuários alvejados:",
+      "blockedByFail2ban": "fail2ban bloqueou",
+      "underObservation": "sob observação"
+    },
+    "session": {
+      "title": "Resumo da Sessão",
+      "attempts1h": "Tentativas / 1h",
+      "attempts24h": "Tentativas / 24h",
+      "uniqueIps": "IPs únicos / 24h",
+      "topTarget": "Usuário mais visado"
+    },
+    "fail2ban": {
+      "title": "fail2ban",
+      "bansLast24h": "{{count}} IPs banidos nas últimas 24h."
+    }
+  },
+  "alerts": {
+    "title": "Central de Alertas",
+    "activeRules": "{{count}} regras ativas",
+    "firingNow_one": "{{count}} regra disparando agora",
+    "firingNow_other": "{{count}} regras disparando agora",
+    "quiet": "Quiet — nenhuma regra disparando.",
+    "dormant_one": "{{count}} dormente",
+    "dormant_other": "{{count}} dormentes",
+    "rule": {
+      "currentValue": "valor atual",
+      "margin": "margem",
+      "state": {
+        "active": "ATIVA",
+        "quiet": "QUIET",
+        "dormant": "DORMENTE",
+        "firing": "DISPARANDO"
+      },
+      "stateHint": {
+        "active": "pode disparar",
+        "quiet": "tudo dentro do esperado",
+        "dormant": "nunca disparou — verificar",
+        "firing": "evento aberto"
+      },
+      "firedCount": "Disparou {{count}}× nos últimos 7d",
+      "pattern": "padrão",
+      "lastFire": "último disparo",
+      "neverFired": "nunca disparou"
+    },
+    "webhook": {
+      "title": "Webhook de notificações",
+      "desc": "Chamado a cada evento FIRING e RESOLVED. Compatível com Slack Incoming Webhooks.",
+      "placeholder": "https://hooks.slack.com/services/…"
+    },
+    "detection": {
+      "label": "Modo de Detecção",
+      "static": "Estático",
+      "ml": "ML",
+      "both": "Ambos (ML + Estático)",
+      "scoreThreshold": "Score mínimo de anomalia"
+    }
+  },
+  "logs": {
+    "title": "Explorador de Logs",
+    "liveLabel": "AO VIVO",
+    "pauseLabel": "PAUSAR",
+    "clearLabel": "LIMPAR",
+    "noLogs": "Nenhum log ainda — selecione um arquivo acima."
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
+import './i18n'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -40,6 +40,8 @@ export const serversApi = {
     http.get<ServerStatus[]>('/servers').then((r) => r.data),
   status: (serverId: string): Promise<ServerStatus> =>
     http.get<ServerStatus>(`/servers/${serverId}/status`).then((r) => r.data),
+  healthSnapshot: (serverId: string): Promise<ServerHealthSnapshot> =>
+    http.get<ServerHealthSnapshot>(`/servers/${serverId}/health-snapshot`).then((r) => r.data),
 }
 
 export const metricsApi = {
@@ -110,6 +112,12 @@ export interface SshEventsResponse {
 export const securityApi = {
   sshEvents: (serverId: string): Promise<SshEventsResponse> =>
     http.get<SshEventsResponse>(`/security/${serverId}/ssh-events`).then((r) => r.data),
+  attackers: (serverId: string): Promise<AttackersResponse> =>
+    http.get<AttackersResponse>(`/security/${serverId}/attackers`).then((r) => r.data),
+  attackByHour: (serverId: string): Promise<AttackByHourResponse> =>
+    http.get<AttackByHourResponse>(`/security/${serverId}/attack-by-hour`).then((r) => r.data),
+  sshBaseline: (serverId: string): Promise<SshBaselineResponse> =>
+    http.get<SshBaselineResponse>(`/security/${serverId}/ssh-baseline`).then((r) => r.data),
 }
 
 export const inventoryApi = {
@@ -192,6 +200,79 @@ export interface WebhookConfig {
   url: string | null
 }
 
+// ── Health snapshot ──────────────────────────────────────────────────────────
+
+export interface MetricHealth {
+  value: number | null
+  baseline: number | null
+  threshold: number
+  trend: 'up' | 'down' | 'stable'
+  spark: number[]
+  projection: string | null
+}
+
+export interface CriticalService {
+  name: string
+  ok: boolean
+}
+
+export interface ServerHealthSnapshot {
+  server_id: string
+  state: 'ok' | 'attention' | 'critical' | 'quiet'
+  cpu: MetricHealth
+  memory: MetricHealth
+  disk: MetricHealth
+  anomalies6h: number
+  critical_services: CriticalService[]
+  headline: string
+}
+
+// ── Security V2 ──────────────────────────────────────────────────────────────
+
+export interface Attacker {
+  ip: string
+  attempts: number
+  users: string[]
+  last_seen: string
+  blocked: boolean
+}
+
+export interface AttackHourBucket {
+  hour: number
+  count: number
+}
+
+export interface AttackersResponse {
+  server_id: string
+  attackers: Attacker[]
+}
+
+export interface AttackByHourResponse {
+  server_id: string
+  hours: AttackHourBucket[]
+}
+
+export interface SshBaselineResponse {
+  server_id: string
+  avg_daily: number
+}
+
+// ── Alert patterns ────────────────────────────────────────────────────────────
+
+export interface RulePattern {
+  rule_id: string
+  fires7d: number
+  last_fire: string | null
+  peak_window: string
+  current_value: number | null
+  state: 'dormant' | 'quiet' | 'active' | 'firing'
+}
+
+export interface RulePatternsResponse {
+  server_id: string
+  patterns: RulePattern[]
+}
+
 export const alertsApi = {
   events: (serverId: string, limit = 100): Promise<AlertEventsResponse> =>
     http.get<AlertEventsResponse>(`/alerts/${serverId}/events`, { params: { limit } }).then((r) => r.data),
@@ -207,4 +288,6 @@ export const alertsApi = {
     http.put<WebhookConfig>(`/alerts/${serverId}/webhook`, { url }).then((r) => r.data),
   deleteWebhook: (serverId: string): Promise<void> =>
     http.delete(`/alerts/${serverId}/webhook`).then(() => undefined),
+  rulePatterns: (serverId: string): Promise<RulePatternsResponse> =>
+    http.get<RulePatternsResponse>(`/alerts/${serverId}/rule-patterns`).then((r) => r.data),
 }


### PR DESCRIPTION
## Summary

- **Backend — health snapshot**: `GET /servers/{id}/health-snapshot` returns per-server health state (ok/attention/critical/quiet), CPU/RAM/disk with current value + 7d baseline + sparkline (30 evenly-sampled points) + trend direction + memory-to-threshold projection, anomaly count (6h), critical services list, and a headline sentence
- **Backend — security V2**: `GET /security/{id}/attackers` (grouped by IP with targeted users + blocked heuristic), `/attack-by-hour` (24 hourly buckets), `/ssh-baseline` (7d daily average)
- **Backend — alert patterns**: `GET /alerts/{id}/rule-patterns` returns per-rule: fires7d, last fire, peak window hour, current metric value, state (dormant/quiet/active/firing)
- **Frontend — i18n**: react-i18next + LanguageDetector, EN primary + PT-BR, localStorage persistence at key `maestro_lang`. Language toggle (EN / PT) added to topbar right
- **Frontend — primitives**: `Sparkline` (SVG, area gradient, optional baseline line), `HealthScore` (i18n pill with state dot), `TrendBar` (progress bar with threshold + baseline markers), `BaselineDelta` (+Xpp color-coded delta)
- **Frontend — API + hooks**: all new types + `useHealthSnapshot`, `useAttackers`, `useAttackByHour`, `useSshBaseline`, `useRulePatterns`

## Components Changed

- [x] API (Python)
- [x] Frontend (React)
- [ ] Agent (Go)
- [ ] Infra / Config

## Test Plan

- [ ] `npx tsc -b --noEmit` — 0 errors ✅
- [ ] Deploy to VPS, call `GET /servers/{id}/health-snapshot` — verify state/headline/sparklines
- [ ] `/security/{id}/attackers` — verify IP grouping matches auth.log
- [ ] Language toggle in topbar switches EN ↔ PT-BR (persists on reload)
- [ ] HealthScore pill renders correct label in each language

## Notes

This is the foundation sprint for the V2 redesign. No existing components have been touched yet — all changes are additive. Sprints C+ will rewrite Dashboard, Infrastructure, Security, Alerts, and ServerDashboard to consume these endpoints and primitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)