### PR TITLE
feat(frontend): V2 redesign — Dashboard, Infrastructure, Security, Alerts, ServerDashboard + full i18n

### DIFF
--- a/frontend/src/components/Alerts.tsx
+++ b/frontend/src/components/Alerts.tsx
@@ -1,28 +1,49 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import Layout from './Layout'
 import type { ViewType } from '../App'
-import { AlertTriangle, CheckCircle, Clock, Plus, Trash2, X, Loader2, Webhook, Save } from 'lucide-react'
+import {
+  AlertTriangle, CheckCircle, Clock, Plus, Trash2, X, Loader2,
+  Webhook, Save, Bell, BellOff, Activity, Minus,
+} from 'lucide-react'
 import { useUIStore } from '../store/uiStore'
 import { useServers } from '../hooks/useServers'
-import { useAlertEvents, useAlertRules, useCreateAlertRule, useDeleteAlertRule, useWebhookConfig, useSaveWebhook, useDeleteWebhook } from '../hooks/useAlerts'
-import type { AlertRuleIn } from '../services/api'
+import {
+  useAlertEvents, useAlertRules, useCreateAlertRule,
+  useDeleteAlertRule, useWebhookConfig, useSaveWebhook, useDeleteWebhook,
+} from '../hooks/useAlerts'
+import { useRulePatterns } from '../hooks/useMetrics'
+import { TrendBar } from './primitives'
+import type { AlertRule, AlertRuleIn, RulePattern } from '../services/api'
 
 interface AlertsProps {
   setView: (view: ViewType) => void
 }
 
 const OPERATORS = ['>', '<', '>=', '<=', '==']
-const METRICS_COMMON = ['cpu_percent', 'memory_percent', 'disk_percent', 'load_1m']
+const METRICS_COMMON = ['cpu_usage_percent', 'memory_usage_percent', 'disk_usage_percent', 'load_1m']
 
-const severityBadge = (s: 'warning' | 'critical') =>
-  s === 'critical'
-    ? 'bg-red-500/10 text-red-400 border-red-500/20'
-    : 'bg-orange-500/10 text-orange-400 border-orange-500/20'
+type RuleState = 'dormant' | 'quiet' | 'active' | 'firing'
+
+const STATE_CONF: Record<RuleState, { bg: string; text: string; border: string }> = {
+  firing:  { bg: 'bg-red-500/15',    text: 'text-red-400',       border: 'border-red-500/30' },
+  active:  { bg: 'bg-amber-500/15',  text: 'text-amber-400',     border: 'border-amber-500/30' },
+  quiet:   { bg: 'bg-slate-500/15',  text: 'text-slate-400',     border: 'border-slate-500/30' },
+  dormant: { bg: 'bg-slate-800/60',  text: 'text-slate-600',     border: 'border-slate-700/40' },
+}
+
+const SEV_CONF = {
+  critical: 'bg-red-500/10 text-red-400 border-red-500/20',
+  warning:  'bg-orange-500/10 text-orange-400 border-orange-500/20',
+}
+
+// ── Rule creation form ────────────────────────────────────────────────────────
 
 function RuleForm({ serverId, onClose }: { serverId: string; onClose: () => void }) {
+  const { t } = useTranslation()
   const create = useCreateAlertRule(serverId)
   const [form, setForm] = useState<AlertRuleIn>({
-    metric_name: 'cpu_percent',
+    metric_name: 'cpu_usage_percent',
     operator: '>',
     threshold: 80,
     severity: 'warning',
@@ -48,18 +69,15 @@ function RuleForm({ serverId, onClose }: { serverId: string; onClose: () => void
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
-      <form
-        onSubmit={handleSubmit}
-        className="glass-card w-full max-w-md p-6 space-y-4 relative"
-      >
+      <form onSubmit={handleSubmit} className="glass-card w-full max-w-md p-6 space-y-4 relative">
         <div className="flex items-center justify-between mb-2">
-          <h3 className="text-base font-bold">Nova Regra de Alerta</h3>
+          <h3 className="text-base font-bold">{t('common.newRule')}</h3>
           <button type="button" onClick={onClose} className="text-slate-500 hover:text-white">
             <X className="w-4 h-4" />
           </button>
         </div>
 
-        {field('Métrica',
+        {field(t('health.metrics.cpu') + ' / Metric',
           <input
             list="metric-suggestions"
             value={form.metric_name}
@@ -72,21 +90,21 @@ function RuleForm({ serverId, onClose }: { serverId: string; onClose: () => void
           {METRICS_COMMON.map((m) => <option key={m} value={m} />)}
         </datalist>
 
-        {field('Modo de Detecção',
+        {field(t('alerts.detection.label'),
           <select value={form.alert_mode} onChange={(e) => setForm({ ...form, alert_mode: e.target.value })} className={inputCls}>
-            <option value="static">Estático (threshold fixo)</option>
-            <option value="ml">ML (score de anomalia)</option>
-            <option value="both">Ambos (estático OU ML)</option>
+            <option value="static">{t('alerts.detection.static')}</option>
+            <option value="ml">{t('alerts.detection.ml')}</option>
+            <option value="both">{t('alerts.detection.both')}</option>
           </select>
         )}
 
         <div className="grid grid-cols-2 gap-3">
-          {field('Operador',
+          {field('Operator',
             <select value={form.operator} onChange={(e) => setForm({ ...form, operator: e.target.value })} className={inputCls}>
               {OPERATORS.map((o) => <option key={o}>{o}</option>)}
             </select>
           )}
-          {field('Threshold',
+          {field(t('health.metrics.threshold'),
             <input
               type="number"
               step="any"
@@ -98,23 +116,22 @@ function RuleForm({ serverId, onClose }: { serverId: string; onClose: () => void
           )}
         </div>
 
-        {usesML && field('Score de Anomalia (0–1)',
+        {usesML && field(t('alerts.detection.scoreThreshold'),
           <div className="flex items-center gap-3">
             <input
-              type="range"
-              min={0}
-              max={1}
-              step={0.05}
+              type="range" min={0} max={1} step={0.05}
               value={form.ml_score_threshold}
               onChange={(e) => setForm({ ...form, ml_score_threshold: parseFloat(e.target.value) })}
               className="flex-1 accent-brand-purple"
             />
-            <span className="font-mono text-sm text-slate-200 w-10 text-right">{form.ml_score_threshold?.toFixed(2)}</span>
+            <span className="font-mono text-sm text-slate-200 w-10 text-right">
+              {form.ml_score_threshold?.toFixed(2)}
+            </span>
           </div>
         )}
 
         <div className="grid grid-cols-2 gap-3">
-          {field('Severidade',
+          {field('Severity',
             <select value={form.severity} onChange={(e) => setForm({ ...form, severity: e.target.value as 'warning' | 'critical' })} className={inputCls}>
               <option value="warning">Warning</option>
               <option value="critical">Critical</option>
@@ -122,9 +139,7 @@ function RuleForm({ serverId, onClose }: { serverId: string; onClose: () => void
           )}
           {field('Cooldown (min)',
             <input
-              type="number"
-              min={1}
-              max={1440}
+              type="number" min={1} max={1440}
               value={form.cooldown_minutes}
               onChange={(e) => setForm({ ...form, cooldown_minutes: parseInt(e.target.value) })}
               className={inputCls}
@@ -139,17 +154,137 @@ function RuleForm({ serverId, onClose }: { serverId: string; onClose: () => void
           className="w-full mt-2 py-2 rounded-lg bg-brand-purple hover:bg-brand-purple/80 text-white text-sm font-bold transition-all disabled:opacity-50 flex items-center justify-center gap-2"
         >
           {create.isPending && <Loader2 className="w-4 h-4 animate-spin" />}
-          Criar Regra
+          {t('common.newRule')}
         </button>
         {create.isError && (
-          <p className="text-xs text-red-400 text-center">Erro ao criar regra. Verifique os campos.</p>
+          <p className="text-xs text-red-400 text-center">Failed to create rule. Check the fields.</p>
         )}
       </form>
     </div>
   )
 }
 
+// ── Living rule card ──────────────────────────────────────────────────────────
+
+function LivingRuleCard({
+  rule,
+  pattern,
+  onDelete,
+  deleting,
+}: {
+  rule: AlertRule
+  pattern: RulePattern | null
+  onDelete: () => void
+  deleting: boolean
+}) {
+  const { t } = useTranslation()
+  const state: RuleState = pattern?.state ?? 'quiet'
+  const sc = STATE_CONF[state]
+  const margin = pattern?.current_value != null
+    ? Math.max(0, rule.threshold - pattern.current_value)
+    : null
+
+  return (
+    <div className={`glass-card overflow-hidden border-l-2 ${
+      state === 'firing'  ? 'border-l-red-500'
+    : state === 'active'  ? 'border-l-amber-500'
+    : state === 'dormant' ? 'border-l-slate-700'
+    :                       'border-l-slate-600'
+    }`}>
+      {/* Header */}
+      <div className="px-4 pt-4 pb-3 flex items-start gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="font-mono text-sm font-bold text-slate-100">{rule.metric_name}</span>
+            <span className="font-mono text-brand-purple text-sm">{rule.operator}</span>
+            <span className="font-mono text-sm text-slate-100">{rule.threshold}</span>
+            <span className={`text-[10px] font-bold uppercase px-2 py-0.5 rounded-full border ${SEV_CONF[rule.severity]}`}>
+              {rule.severity}
+            </span>
+            {rule.alert_mode && rule.alert_mode !== 'static' && (
+              <span className="text-[10px] font-bold uppercase px-2 py-0.5 rounded-full border bg-brand-purple/10 text-brand-purple border-brand-purple/20">
+                {rule.alert_mode === 'ml' ? 'ML' : 'ML+static'}
+              </span>
+            )}
+          </div>
+          <p className="text-[11px] text-slate-500 mt-1 font-mono">
+            cooldown {rule.cooldown_minutes}min
+            {rule.alert_mode !== 'static' && ` · score ≥ ${rule.ml_score_threshold?.toFixed(2)}`}
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2 shrink-0">
+          <span className={`text-[10px] font-bold uppercase px-2 py-1 rounded-md border ${sc.bg} ${sc.text} ${sc.border}`}>
+            {t(`alerts.rule.state.${state}`)}
+          </span>
+          <button
+            onClick={onDelete}
+            disabled={deleting}
+            className="text-slate-600 hover:text-red-400 transition-colors"
+            title="Remove rule"
+          >
+            {deleting ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Trash2 className="w-3.5 h-3.5" />}
+          </button>
+        </div>
+      </div>
+
+      {/* Current value meter */}
+      {pattern?.current_value != null && (
+        <div className="px-4 pb-3 space-y-1">
+          <div className="grid items-center gap-x-2" style={{ gridTemplateColumns: '80px 1fr auto' }}>
+            <span className="text-[10px] text-slate-500 uppercase tracking-widest">{t('alerts.rule.currentValue')}</span>
+            <TrendBar
+              value={pattern.current_value}
+              threshold={rule.threshold}
+              color={state === 'firing' ? '#F87171' : state === 'active' ? '#F59E0B' : '#39FF14'}
+              height={4}
+            />
+            <span className="font-mono text-xs font-bold text-slate-200 text-right" style={{ minWidth: 40 }}>
+              {pattern.current_value.toFixed(1)}%
+            </span>
+          </div>
+          {margin != null && (
+            <div className="text-[10px] text-slate-500 ml-20">
+              {t('alerts.rule.margin')}: <span className="font-mono text-slate-400">{margin.toFixed(1)}pp</span>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Pattern footer */}
+      <div className="px-4 py-2.5 bg-white/[0.02] border-t border-white/5 flex items-center gap-4 flex-wrap">
+        <div className="flex items-center gap-1.5 text-[11px]">
+          <Activity className="w-3 h-3 text-slate-500" />
+          <span className="text-slate-400">
+            {t('alerts.rule.firedCount', { count: pattern?.fires7d ?? 0 })}
+          </span>
+          {pattern && pattern.fires7d > 0 && pattern.peak_window !== '—' && (
+            <span className="text-slate-500">· {t('alerts.rule.pattern')} {pattern.peak_window}</span>
+          )}
+        </div>
+
+        <div className="flex items-center gap-1.5 text-[11px] ml-auto">
+          <Clock className="w-3 h-3 text-slate-600" />
+          <span className="text-slate-500 font-mono">
+            {pattern?.last_fire
+              ? `${t('alerts.rule.lastFire')}: ${new Date(pattern.last_fire).toLocaleDateString()}`
+              : t('alerts.rule.neverFired')
+            }
+          </span>
+        </div>
+
+        {state === 'dormant' && (
+          <span className="text-[10px] text-slate-600 italic">{t('alerts.rule.stateHint.dormant')}</span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ── Webhook section ───────────────────────────────────────────────────────────
+
 function WebhookSection({ serverId }: { serverId: string }) {
+  const { t } = useTranslation()
   const { data } = useWebhookConfig(serverId)
   const save = useSaveWebhook(serverId)
   const remove = useDeleteWebhook(serverId)
@@ -163,22 +298,26 @@ function WebhookSection({ serverId }: { serverId: string }) {
     else remove.mutate()
   }
 
+  const hasWebhook = !!(data?.url)
+
   return (
     <section>
       <h2 className="text-base font-bold text-slate-200 mb-4 flex items-center gap-2">
         <Webhook className="w-4 h-4 text-brand-purple" />
-        Notificações via Webhook
+        {t('alerts.webhook.title')}
+        {hasWebhook
+          ? <span className="ml-2 text-[10px] font-bold px-2 py-0.5 rounded-full bg-brand-neon/10 text-brand-neon border border-brand-neon/20 uppercase">active</span>
+          : <span className="ml-2 text-[10px] font-bold px-2 py-0.5 rounded-full bg-slate-800 text-slate-500 border border-slate-700 uppercase">off</span>
+        }
       </h2>
       <div className="glass-card p-5">
-        <p className="text-xs text-slate-400 mb-4">
-          URL compatível com Slack Incoming Webhooks ou qualquer endpoint HTTP POST. Será chamado a cada evento FIRING e RESOLVED.
-        </p>
+        <p className="text-xs text-slate-400 mb-4">{t('alerts.webhook.desc')}</p>
         <form onSubmit={handleSave} className="flex gap-3">
           <input
             type="url"
             value={url}
             onChange={(e) => setUrl(e.target.value)}
-            placeholder="https://hooks.slack.com/services/..."
+            placeholder={t('alerts.webhook.placeholder')}
             className="flex-1 bg-brand-slate border border-white/10 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-brand-purple/50 transition-all font-mono"
           />
           <button
@@ -188,97 +327,144 @@ function WebhookSection({ serverId }: { serverId: string }) {
           >
             {(save.isPending || remove.isPending)
               ? <Loader2 className="w-4 h-4 animate-spin" />
-              : <Save className="w-4 h-4" />
+              : url ? <Save className="w-4 h-4" /> : <Minus className="w-4 h-4" />
             }
-            {url ? 'Salvar' : 'Remover'}
+            {url ? t('common.save') : t('common.delete')}
           </button>
         </form>
-        {save.isSuccess && <p className="text-xs text-brand-neon mt-2">Webhook salvo.</p>}
-        {remove.isSuccess && <p className="text-xs text-slate-400 mt-2">Webhook removido.</p>}
-        {data?.url && !save.isSuccess && (
-          <p className="text-[11px] text-slate-500 mt-2 font-mono truncate">Atual: {data.url}</p>
+        {save.isSuccess && <p className="text-xs text-brand-neon mt-2">Webhook saved.</p>}
+        {remove.isSuccess && <p className="text-xs text-slate-400 mt-2">Webhook removed.</p>}
+        {hasWebhook && !save.isSuccess && (
+          <p className="text-[11px] text-slate-500 mt-2 font-mono truncate">Current: {data.url}</p>
         )}
       </div>
     </section>
   )
 }
 
-const Alerts: React.FC<AlertsProps> = ({ setView }) => {
+// ── Alerts hero strip ─────────────────────────────────────────────────────────
+
+function AlertsHero({
+  rules,
+  patterns,
+}: {
+  rules: AlertRule[]
+  patterns: RulePattern[]
+}) {
+  const { t } = useTranslation()
+  const patMap = Object.fromEntries(patterns.map((p) => [p.rule_id, p]))
+  const firingCount  = rules.filter((r) => patMap[r.rule_id]?.state === 'firing').length
+  const dormantCount = rules.filter((r) => patMap[r.rule_id]?.state === 'dormant').length
+  const activeCount  = rules.filter((r) => patMap[r.rule_id]?.state === 'active').length
+
+  return (
+    <div className="glass-card p-5 mb-8 flex items-center gap-8 flex-wrap">
+      <div className="flex items-center gap-3">
+        {firingCount > 0
+          ? <Bell className="w-5 h-5 text-red-400 animate-pulse" />
+          : <BellOff className="w-5 h-5 text-slate-500" />
+        }
+        <div>
+          <p className="text-[10px] text-slate-500 uppercase tracking-widest">{t('alerts.title')}</p>
+          {firingCount > 0
+            ? <p className="text-base font-bold text-red-400">{t('alerts.firingNow', { count: firingCount })}</p>
+            : <p className="text-base font-bold text-slate-300">{t('alerts.quiet')}</p>
+          }
+        </div>
+      </div>
+
+      <div className="h-8 w-px bg-white/10" />
+
+      <div className="grid grid-cols-3 gap-6">
+        <div className="text-center">
+          <p className="font-mono text-xl font-bold text-slate-100">{rules.length}</p>
+          <p className="text-[10px] text-slate-500 uppercase tracking-widest">{t('alerts.activeRules', { count: rules.length })}</p>
+        </div>
+        <div className="text-center">
+          <p className={`font-mono text-xl font-bold ${activeCount > 0 ? 'text-amber-400' : 'text-slate-600'}`}>{activeCount}</p>
+          <p className="text-[10px] text-slate-500 uppercase tracking-widest">{t('health.state.attention')}</p>
+        </div>
+        <div className="text-center">
+          <p className={`font-mono text-xl font-bold ${dormantCount > 0 ? 'text-slate-500' : 'text-slate-600'}`}>{dormantCount}</p>
+          <p className="text-[10px] text-slate-500 uppercase tracking-widest">{t('alerts.dormant', { count: dormantCount })}</p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+export default function Alerts({ setView }: AlertsProps) {
+  const { t } = useTranslation()
   const selectedAgentId = useUIStore((s) => s.selectedAgentId)
   const { data: servers } = useServers()
   const serverId = selectedAgentId
     ?? servers?.find((s) => s.status === 'online')?.server_id
     ?? servers?.[0]?.server_id
     ?? ''
+
   const [showForm, setShowForm] = useState(false)
 
   const { data: eventsData, isLoading: loadingEvents } = useAlertEvents(serverId)
-  const { data: rulesData, isLoading: loadingRules } = useAlertRules(serverId)
+  const { data: rulesData, isLoading: loadingRules }   = useAlertRules(serverId)
+  const { data: patternsData }                         = useRulePatterns(serverId)
   const deleteRule = useDeleteAlertRule(serverId)
 
-  const fmt = (iso: string) => {
-    const d = new Date(iso)
-    return d.toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' })
-  }
+  const rules    = rulesData?.rules    ?? []
+  const patterns = patternsData?.patterns ?? []
+  const patMap   = Object.fromEntries(patterns.map((p) => [p.rule_id, p]))
+
+  const fmtTs = (iso: string) =>
+    new Date(iso).toLocaleString(undefined, { dateStyle: 'short', timeStyle: 'short' })
 
   return (
-    <Layout currentView="alerts" setView={setView} title="Central de Alertas">
+    <Layout currentView="alerts" setView={setView} title={t('alerts.title')}>
       {showForm && serverId && <RuleForm serverId={serverId} onClose={() => setShowForm(false)} />}
 
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold text-slate-100 mb-1.5">{t('alerts.title')}</h1>
+      </div>
+
+      {rules.length > 0 && (
+        <AlertsHero rules={rules} patterns={patterns} />
+      )}
+
       <div className="space-y-8">
-        {/* Rules */}
+        {/* Active rules */}
         <section>
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-base font-bold text-slate-200">Regras Ativas</h2>
+            <h2 className="text-sm font-bold text-slate-400 uppercase tracking-widest">
+              {t('alerts.activeRules', { count: rules.length })}
+            </h2>
             {!!serverId && (
               <button
                 onClick={() => setShowForm(true)}
                 className="flex items-center gap-2 text-xs font-bold text-brand-purple bg-brand-purple/10 border border-brand-purple/20 px-3 py-1.5 rounded-lg hover:bg-brand-purple/20 transition-all"
               >
                 <Plus className="w-3.5 h-3.5" />
-                Nova Regra
+                {t('common.newRule')}
               </button>
             )}
           </div>
 
           {loadingRules ? (
-            <div className="flex items-center gap-2 text-slate-500 text-sm"><Loader2 className="w-4 h-4 animate-spin" /> Carregando regras...</div>
-          ) : rulesData?.rules.length === 0 ? (
-            <p className="text-slate-500 text-sm">Nenhuma regra configurada.</p>
+            <div className="flex items-center gap-2 text-slate-500 text-sm">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              <span>{t('common.loading')}</span>
+            </div>
+          ) : rules.length === 0 ? (
+            <p className="text-slate-500 text-sm">{t('alerts.quiet')}</p>
           ) : (
-            <div className="space-y-2">
-              {rulesData?.rules.map((rule) => (
-                <div key={rule.rule_id} className="glass-card p-4 flex items-center gap-4">
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <span className="font-mono text-sm text-slate-200">{rule.metric_name}</span>
-                      <span className="font-mono text-brand-purple">{rule.operator}</span>
-                      <span className="font-mono text-slate-200">{rule.threshold}</span>
-                      <span className={`text-[10px] font-bold uppercase px-2 py-0.5 rounded-full border ${severityBadge(rule.severity)}`}>
-                        {rule.severity}
-                      </span>
-                      {rule.alert_mode && rule.alert_mode !== 'static' && (
-                        <span className="text-[10px] font-bold uppercase px-2 py-0.5 rounded-full border bg-brand-purple/10 text-brand-purple border-brand-purple/20">
-                          {rule.alert_mode === 'ml' ? 'ML' : 'ML+static'}
-                        </span>
-                      )}
-                    </div>
-                    <p className="text-[11px] text-slate-500 mt-1">
-                      Cooldown {rule.cooldown_minutes}min &bull; Criado {fmt(rule.created_at)}
-                      {rule.alert_mode && rule.alert_mode !== 'static' && (
-                        <> &bull; Score ≥ {rule.ml_score_threshold?.toFixed(2)}</>
-                      )}
-                    </p>
-                  </div>
-                  <button
-                    onClick={() => deleteRule.mutate(rule.rule_id)}
-                    disabled={deleteRule.isPending}
-                    className="text-slate-600 hover:text-red-400 transition-colors shrink-0"
-                    title="Remover regra"
-                  >
-                    <Trash2 className="w-4 h-4" />
-                  </button>
-                </div>
+            <div className="space-y-3">
+              {rules.map((rule) => (
+                <LivingRuleCard
+                  key={rule.rule_id}
+                  rule={rule}
+                  pattern={patMap[rule.rule_id] ?? null}
+                  onDelete={() => deleteRule.mutate(rule.rule_id)}
+                  deleting={deleteRule.isPending}
+                />
               ))}
             </div>
           )}
@@ -287,42 +473,63 @@ const Alerts: React.FC<AlertsProps> = ({ setView }) => {
         {/* Webhook */}
         {serverId && <WebhookSection serverId={serverId} />}
 
-        {/* Events */}
+        {/* Events history */}
         <section>
-          <h2 className="text-base font-bold text-slate-200 mb-4">Histórico de Eventos</h2>
+          <h2 className="text-sm font-bold text-slate-400 uppercase tracking-widest mb-4">
+            {t('common.events')} — 24h
+          </h2>
 
           {loadingEvents ? (
-            <div className="flex items-center gap-2 text-slate-500 text-sm"><Loader2 className="w-4 h-4 animate-spin" /> Carregando eventos...</div>
-          ) : eventsData?.events.length === 0 ? (
-            <p className="text-slate-500 text-sm">Nenhum evento registrado.</p>
+            <div className="flex items-center gap-2 text-slate-500 text-sm">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              <span>{t('common.loading')}</span>
+            </div>
+          ) : !eventsData?.events.length ? (
+            <div className="glass-card p-6 text-center">
+              <CheckCircle className="w-8 h-8 text-brand-neon/30 mx-auto mb-2" />
+              <p className="text-slate-500 text-sm">{t('dashboard.incidents.quiet')}</p>
+            </div>
           ) : (
-            <div className="space-y-2">
-              {eventsData?.events.map((event) => (
-                <div key={event.event_id} className="glass-card p-4 flex gap-4">
-                  <div className="shrink-0 mt-0.5">
-                    {event.state === 'FIRING'
-                      ? <AlertTriangle className={`w-4 h-4 ${event.severity === 'critical' ? 'text-red-400' : 'text-orange-400'}`} />
-                      : <CheckCircle className="w-4 h-4 text-brand-neon" />
-                    }
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <span className="font-bold text-sm text-slate-200">{event.metric_name}</span>
-                      <span className={`text-[10px] font-bold uppercase px-2 py-0.5 rounded-full border ${event.state === 'FIRING' ? severityBadge(event.severity) : 'bg-brand-neon/10 text-brand-neon border-brand-neon/20'}`}>
-                        {event.state}
-                      </span>
-                    </div>
-                    <p className="text-xs text-slate-400 mt-0.5">
-                      Valor: <span className="font-mono text-slate-200">{event.value.toFixed(2)}</span>
-                      {' '}&bull; Threshold: <span className="font-mono text-slate-200">{event.threshold}</span>
-                    </p>
-                  </div>
-                  <div className="flex items-center gap-1 text-[10px] text-slate-500 font-mono shrink-0">
-                    <Clock className="w-3 h-3" />
-                    <span>{fmt(event.triggered_at)}</span>
-                  </div>
-                </div>
-              ))}
+            <div className="glass-card overflow-hidden">
+              <table className="w-full text-left">
+                <thead className="text-[10px] text-slate-500 uppercase tracking-widest bg-brand-dark/20">
+                  <tr>
+                    <th className="px-4 py-2 font-medium">State</th>
+                    <th className="px-4 py-2 font-medium">Metric</th>
+                    <th className="px-4 py-2 font-medium">Value</th>
+                    <th className="px-4 py-2 font-medium">Threshold</th>
+                    <th className="px-4 py-2 font-medium">Time</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-white/5">
+                  {eventsData.events.map((event) => (
+                    <tr key={event.event_id} className="hover:bg-white/5 transition-colors">
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-1.5">
+                          {event.state === 'FIRING'
+                            ? <AlertTriangle className={`w-3.5 h-3.5 ${event.severity === 'critical' ? 'text-red-400' : 'text-orange-400'}`} />
+                            : <CheckCircle className="w-3.5 h-3.5 text-brand-neon" />
+                          }
+                          <span className={`text-[10px] font-bold uppercase ${
+                            event.state === 'FIRING'
+                              ? event.severity === 'critical' ? 'text-red-400' : 'text-orange-400'
+                              : 'text-brand-neon'
+                          }`}>
+                            {event.state}
+                          </span>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 font-mono text-xs text-slate-300">{event.metric_name}</td>
+                      <td className="px-4 py-3 font-mono text-xs text-slate-200">{event.value.toFixed(2)}</td>
+                      <td className="px-4 py-3 font-mono text-xs text-slate-400">{event.threshold}</td>
+                      <td className="px-4 py-3 font-mono text-[11px] text-slate-500 flex items-center gap-1">
+                        <Clock className="w-3 h-3" />
+                        {fmtTs(event.triggered_at)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
             </div>
           )}
         </section>
@@ -330,5 +537,3 @@ const Alerts: React.FC<AlertsProps> = ({ setView }) => {
     </Layout>
   )
 }
-
-export default Alerts

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,109 +1,619 @@
-import React from 'react'
-import { Activity, Shield, Server } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { useQueries } from '@tanstack/react-query'
+import { AlertTriangle, CheckCircle, WifiOff, Activity, ShieldCheck, ArrowRight } from 'lucide-react'
 import Layout from './Layout'
 import type { ViewType } from '../App'
+import { HealthScore, TrendBar, Sparkline, BaselineDelta } from './primitives'
+import type { HealthState } from './primitives'
+import type { ServerHealthSnapshot, AnomalyScore, AlertEvent } from '../services/api'
+import { serversApi } from '../services/api'
 import { useServers } from '../hooks/useServers'
+import { useAlertEvents } from '../hooks/useAlerts'
+import { useSshEvents } from '../hooks/useSecurity'
+import { useAttackByHour, useSshBaseline, useAnomalyScores } from '../hooks/useMetrics'
 import { useUIStore } from '../store/uiStore'
+import type { ServerStatus } from '../types/server'
 
 interface DashboardProps {
   setView: (view: ViewType) => void
 }
 
-const Dashboard: React.FC<DashboardProps> = ({ setView }) => {
-  const { data: servers, isLoading } = useServers()
-  const setSelectedAgentId = useUIStore((s) => s.setSelectedAgentId)
+// ── Helpers ───────────────────────────────────────────────────────────────────
 
-  const online  = servers?.filter((s) => s.status === 'online').length  ?? 0
-  const offline = servers?.filter((s) => s.status === 'offline').length ?? 0
-  const total   = servers?.length ?? 0
+function relative(iso: string): string {
+  const diff = Math.floor((Date.now() - new Date(iso).getTime()) / 1000)
+  if (diff < 60)    return `${diff}s ago`
+  if (diff < 3600)  return `${Math.floor(diff / 60)}min ago`
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
+  return `${Math.floor(diff / 86400)}d ago`
+}
+
+const STATE_COLOR: Record<HealthState | 'quiet', string> = {
+  ok:        '#34D399',
+  attention: '#F59E0B',
+  critical:  '#F87171',
+  quiet:     '#94A3B8',
+}
+
+interface FleetEntry extends ServerStatus {
+  snapshot: ServerHealthSnapshot | null
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function FleetTallyDot({ count, state }: { count: number; state: HealthState }) {
+  if (!count) return null
+  const { t } = useTranslation()
+  const color = STATE_COLOR[state]
+  return (
+    <div className="flex items-center gap-1.5">
+      <span style={{
+        width: 8, height: 8, borderRadius: '50%', background: color,
+        boxShadow: state === 'ok' ? `0 0 6px ${color}88` : 'none',
+        flexShrink: 0,
+      }} />
+      <span className="font-mono text-sm font-bold text-slate-100">{count}</span>
+      <span className="text-xs text-slate-400">{t(`health.state.${state}`)}</span>
+    </div>
+  )
+}
+
+function FocusHero({
+  server,
+  snapshot,
+  onOpen,
+}: {
+  server: FleetEntry
+  snapshot: ServerHealthSnapshot | null
+  onOpen: () => void
+}) {
+  const { t } = useTranslation()
+  if (!snapshot) return null
+
+  const state = snapshot.state as HealthState
+  const conf = {
+    ok:        { fg: '#34D399', soft: 'rgba(52,211,153,0.06)',  border: 'rgba(52,211,153,0.20)' },
+    attention: { fg: '#F59E0B', soft: 'rgba(245,158,11,0.06)',  border: 'rgba(245,158,11,0.22)' },
+    critical:  { fg: '#F87171', soft: 'rgba(239,68,68,0.06)',   border: 'rgba(239,68,68,0.22)'  },
+    quiet:     { fg: '#94A3B8', soft: 'rgba(148,163,184,0.06)', border: 'rgba(148,163,184,0.20)' },
+  }[state]
 
   return (
-    <Layout currentView="dashboard" setView={setView} title="Observabilidade Geral">
-      <div className="space-y-8">
-        {/* Stats */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          <div className="glass-card p-6 border-l-4 border-l-brand-purple/50">
-            <div className="flex justify-between items-start mb-2">
-              <span className="text-slate-400 text-xs font-semibold uppercase tracking-wider">Servidores Ativos</span>
-              <Server className="w-5 h-5 text-brand-purple" />
-            </div>
-            <div className="flex items-baseline gap-2">
-              <span className="text-2xl font-bold font-mono">{isLoading ? '…' : online}</span>
-              {!isLoading && (
-                <span className="text-[10px] font-semibold text-slate-400">de {total} ({offline} offline)</span>
-              )}
-            </div>
-          </div>
+    <div
+      className="glass-card"
+      style={{
+        padding: 24, position: 'relative', overflow: 'hidden',
+        borderColor: conf.border,
+        background: `linear-gradient(180deg, ${conf.soft} 0%, transparent 50%), rgba(30,41,59,0.4)`,
+      }}
+    >
+      <div className="flex items-center gap-3 mb-4">
+        <span className="text-[11px] font-mono font-bold uppercase tracking-widest" style={{ color: conf.fg }}>
+          {t('common.focusHere')}
+        </span>
+        <HealthScore state={state} size="sm" />
+        <span className="font-mono text-lg font-bold tracking-tight text-slate-100">{server.server_id}</span>
+        <span className="flex-1" />
+        <button
+          onClick={onOpen}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-brand-purple/10 border border-brand-purple/30 text-brand-purple text-xs font-semibold hover:bg-brand-purple/20 transition-colors"
+        >
+          {t('common.openServer')}
+          <ArrowRight size={12} />
+        </button>
+      </div>
 
-          <div className="glass-card p-6 border-l-4 border-l-brand-neon/50">
-            <div className="flex justify-between items-start mb-2">
-              <span className="text-slate-400 text-xs font-semibold uppercase tracking-wider">Agentes Online</span>
-              <Activity className="w-5 h-5 text-brand-neon" />
-            </div>
-            <div className="flex items-baseline gap-2">
-              <span className="text-2xl font-bold font-mono">{isLoading ? '…' : online}</span>
-              <span className="text-[10px] font-semibold text-brand-neon">coletando métricas</span>
-            </div>
-          </div>
+      {snapshot.headline && (
+        <p className="text-sm text-slate-100 font-medium mb-5">{snapshot.headline}</p>
+      )}
 
-          <div className="glass-card p-6 border-l-4 border-l-brand-neon/50">
-            <div className="flex justify-between items-start mb-2">
-              <span className="text-slate-400 text-xs font-semibold uppercase tracking-wider">Incidentes Críticos</span>
-              <Shield className="w-5 h-5 text-brand-neon" />
+      <div className="grid grid-cols-3 gap-8">
+        <MetricBlock
+          label={t('health.metrics.cpu')}
+          metric={snapshot.cpu}
+          color="#39FF14"
+        />
+        <MetricBlock
+          label={t('health.metrics.memory')}
+          metric={snapshot.memory}
+          color="#7C3AED"
+        />
+        <MetricBlock
+          label={t('health.metrics.disk')}
+          metric={snapshot.disk}
+          color="#F59E0B"
+        />
+      </div>
+
+      <div className="flex items-center gap-6 mt-5 pt-4 border-t border-white/5 text-xs text-slate-400">
+        {snapshot.anomalies6h > 0 && (
+          <span className="flex items-center gap-1.5">
+            <Activity size={12} className="text-brand-purple" />
+            {t('health.anomalies6h', { count: snapshot.anomalies6h })}
+          </span>
+        )}
+        <span className="flex-1" />
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] font-mono uppercase tracking-widest text-slate-500">
+            {t('common.criticalServices')}
+          </span>
+          {snapshot.critical_services.map((svc) => (
+            <div
+              key={svc.name}
+              title={`${svc.name} · ${svc.ok ? 'active' : 'failed'}`}
+              className="flex items-center gap-1 px-1.5 py-0.5 rounded"
+              style={{
+                background: svc.ok ? 'rgba(57,255,20,0.05)' : 'rgba(239,68,68,0.10)',
+                border: `1px solid ${svc.ok ? 'rgba(57,255,20,0.15)' : 'rgba(239,68,68,0.25)'}`,
+                fontSize: 11, fontFamily: 'monospace',
+                color: svc.ok ? '#39FF14' : '#F87171',
+              }}
+            >
+              <span style={{
+                width: 4, height: 4, borderRadius: '50%',
+                background: 'currentColor',
+                boxShadow: svc.ok ? '0 0 4px currentColor' : 'none',
+              }} />
+              {svc.name}
             </div>
-            <div className="flex items-baseline gap-2">
-              <span className="text-2xl font-bold font-mono">0</span>
-              <span className="text-[10px] font-semibold text-slate-400">last 24h</span>
-            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function MetricBlock({
+  label,
+  metric,
+  color,
+}: {
+  label: string
+  metric: ServerHealthSnapshot['cpu']
+  color: string
+}) {
+  if (!metric) return null
+
+  return (
+    <div className="flex flex-col gap-1.5 min-w-0">
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="text-[10px] font-bold uppercase tracking-widest text-slate-500">{label}</span>
+        <BaselineDelta value={metric.value} baseline={metric.baseline} unit="pp" />
+      </div>
+      <div className="flex items-baseline gap-1.5">
+        <span className="font-mono text-2xl font-bold text-slate-100 tabular-nums">
+          {metric.value ?? '—'}
+        </span>
+        <span className="text-xs text-slate-400">%</span>
+        {metric.baseline != null && (
+          <span className="font-mono text-[11px] text-slate-500 ml-1">avg {metric.baseline}</span>
+        )}
+      </div>
+      <TrendBar
+        value={metric.value ?? 0}
+        max={metric.threshold * 1.2}
+        threshold={metric.threshold}
+        baseline={metric.baseline ?? undefined}
+        color={color}
+        height={6}
+      />
+      {metric.spark.length > 1 && (
+        <Sparkline data={metric.spark} color={color} width={160} height={20} />
+      )}
+      {metric.projection && (
+        <div className="text-[11px] text-amber-400 mt-0.5">↗ {metric.projection}</div>
+      )}
+    </div>
+  )
+}
+
+function IncidentsCard({
+  events,
+  firingNow,
+  onViewAlerts,
+}: {
+  events: AlertEvent[]
+  firingNow: AlertEvent[]
+  onViewAlerts: () => void
+}) {
+  const { t } = useTranslation()
+  return (
+    <div className="glass-card p-5">
+      <div className="flex items-baseline justify-between mb-4">
+        <h3 className="text-sm font-bold text-slate-100">{t('dashboard.incidents.title')}</h3>
+        <button
+          onClick={onViewAlerts}
+          className="text-[10px] font-mono text-slate-500 hover:text-brand-purple transition-colors uppercase tracking-widest"
+        >
+          {t('common.viewAll')}
+        </button>
+      </div>
+
+      {events.length === 0 ? (
+        <div className="flex items-center gap-3 p-4 rounded-lg bg-brand-neon/5 border border-brand-neon/20">
+          <CheckCircle size={20} className="text-brand-neon flex-shrink-0" />
+          <div>
+            <div className="text-sm font-bold text-brand-neon">{t('dashboard.incidents.quiet')}</div>
+            <div className="text-xs text-slate-400 mt-0.5">{t('dashboard.incidents.quietDesc')}</div>
           </div>
         </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {firingNow.length > 0 && (
+            <div className="flex items-center gap-2.5 p-2.5 rounded-lg bg-red-500/6 border border-red-500/20">
+              <AlertTriangle size={14} className="text-red-400 flex-shrink-0" />
+              <span className="text-sm font-bold text-red-400">
+                {t('dashboard.incidents.firingNow', { count: firingNow.length })}
+              </span>
+            </div>
+          )}
+          {events.slice(0, 4).map((e) => (
+            <div key={e.event_id} className="flex items-center gap-2.5 py-2 border-b border-white/5 last:border-0">
+              {e.state === 'FIRING'
+                ? <AlertTriangle size={14} style={{ color: e.severity === 'critical' ? '#F87171' : '#FB923C', flexShrink: 0 }} />
+                : <CheckCircle size={14} className="text-brand-neon flex-shrink-0" />
+              }
+              <span className="font-mono text-xs text-slate-200">{e.metric_name}</span>
+              <span className="font-mono text-[11px] text-slate-500">{e.value.toFixed(1)} / {e.threshold}</span>
+              <span className="flex-1" />
+              <span className="text-[11px] text-slate-500">{relative(e.triggered_at)}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
 
-        {/* Server list preview */}
-        <section className="glass-card p-6">
-          <div className="flex justify-between items-center mb-5">
-            <h3 className="font-semibold text-slate-200">Servidores</h3>
+function AnomaliesCard({
+  count6h,
+  mostSevere,
+  onViewServer,
+}: {
+  count6h: number
+  mostSevere: AnomalyScore | null
+  onViewServer: () => void
+}) {
+  const { t } = useTranslation()
+  return (
+    <div className="glass-card p-5">
+      <div className="flex items-baseline justify-between mb-4">
+        <h3 className="text-sm font-bold text-slate-100">{t('dashboard.anomalies.title')}</h3>
+        <button
+          onClick={onViewServer}
+          className="text-[10px] font-mono text-slate-500 hover:text-brand-purple transition-colors uppercase tracking-widest"
+        >
+          {t('common.viewCharts')}
+        </button>
+      </div>
+      <div className="flex items-baseline gap-3 mb-3">
+        <span
+          className="font-mono text-5xl font-bold leading-none tabular-nums"
+          style={{ color: count6h > 0 ? '#F59E0B' : '#39FF14', letterSpacing: '-0.02em' }}
+        >
+          {count6h}
+        </span>
+        <span className="text-xs text-slate-400">{t('dashboard.anomalies.detected', { count: 1 })}</span>
+      </div>
+      {mostSevere && (
+        <div className="text-xs text-slate-300 leading-relaxed">
+          Most severe: <span className="font-mono">cpu_usage_percent</span>
+          <br />
+          <span className="font-mono font-bold" style={{ color: '#F87171' }}>
+            score {mostSevere.score.toFixed(2)}
+          </span>
+          <span className="text-slate-500"> · {relative(mostSevere.timestamp)}</span>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function FleetTile({ server, onClick }: { server: FleetEntry; onClick: () => void }) {
+  const { t } = useTranslation()
+  const h = server.snapshot
+  const state = (h?.state ?? 'quiet') as HealthState
+
+  return (
+    <button
+      onClick={onClick}
+      className="glass-card p-4 text-left cursor-pointer relative overflow-hidden"
+      style={{ transition: 'all 0.15s ease' }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.borderColor = 'rgba(124,58,237,0.40)'
+        e.currentTarget.style.boxShadow = '0 0 20px rgba(124,58,237,0.10)'
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.borderColor = ''
+        e.currentTarget.style.boxShadow = ''
+      }}
+    >
+      <div className="flex items-center gap-2.5 mb-3">
+        <HealthScore state={state} size="sm" />
+        <span className="font-mono text-[13px] font-bold text-slate-100 flex-1 truncate min-w-0">
+          {server.server_id}
+        </span>
+      </div>
+
+      {h?.cpu?.value != null ? (
+        <div className="grid gap-y-1.5" style={{ gridTemplateColumns: '40px 1fr auto', columnGap: 8, alignItems: 'center' }}>
+          <span className="text-[10px] text-slate-500 uppercase font-bold">{t('health.metrics.cpu')}</span>
+          <TrendBar value={h.cpu.value} threshold={h.cpu.threshold} baseline={h.cpu.baseline ?? undefined} color="#39FF14" height={4} />
+          <span className="font-mono text-xs font-bold text-slate-200">{h.cpu.value}%</span>
+
+          <span className="text-[10px] text-slate-500 uppercase font-bold">{t('health.metrics.memory').slice(0,3)}</span>
+          <TrendBar value={h.memory.value ?? 0} threshold={h.memory.threshold} baseline={h.memory.baseline ?? undefined} color="#7C3AED" height={4} />
+          <span className="font-mono text-xs font-bold text-slate-200">{h.memory.value}%</span>
+
+          <span className="text-[10px] text-slate-500 uppercase font-bold">{t('health.metrics.disk').slice(0,3)}</span>
+          <TrendBar value={h.disk.value ?? 0} threshold={h.disk.threshold} baseline={h.disk.baseline ?? undefined} color="#F59E0B" height={4} />
+          <span className="font-mono text-xs font-bold text-slate-200">{h.disk.value}%</span>
+        </div>
+      ) : (
+        <div className="flex items-center gap-2 text-xs text-slate-500">
+          <WifiOff size={13} />
+          <span>offline — no metrics</span>
+        </div>
+      )}
+
+      {(h?.anomalies6h ?? 0) > 0 && (
+        <div className="flex items-center gap-1.5 mt-2.5 text-[10px] text-amber-400">
+          <Activity size={10} />
+          {t('health.anomalies6h', { count: h!.anomalies6h })}
+        </div>
+      )}
+    </button>
+  )
+}
+
+function SecurityPulseCard({
+  sshCount,
+  baseline,
+  delta,
+  hourly,
+  onViewSecurity,
+}: {
+  sshCount: number
+  baseline: number
+  delta: number
+  hourly: { hour: number; count: number }[]
+  onViewSecurity: () => void
+}) {
+  const { t } = useTranslation()
+  const deltaColor = delta > 2 ? '#F87171' : delta > 1.3 ? '#F59E0B' : '#34D399'
+  const sparkData = hourly.map((h) => h.count)
+  const baselinePerHour = baseline / 24
+
+  return (
+    <div className="glass-card p-5 grid items-center gap-6" style={{ gridTemplateColumns: 'auto 1fr auto' }}>
+      <div className="flex items-center gap-3">
+        <div className="w-10 h-10 rounded-xl flex items-center justify-center bg-brand-purple/10 border border-brand-purple/25">
+          <ShieldCheck size={20} className="text-brand-purple" />
+        </div>
+        <div>
+          <div className="text-[10px] font-mono font-bold uppercase tracking-widest text-slate-400">
+            {t('dashboard.security.label')}
+          </div>
+          <div className="text-sm text-slate-100 mt-0.5">
+            <span className="font-mono font-bold">{sshCount.toLocaleString()}</span>
+            <span className="text-slate-400"> {t('dashboard.security.attempts', { count: sshCount })} — </span>
+            <span className="font-mono font-bold" style={{ color: deltaColor }}>{delta.toFixed(1)}×</span>
+            <span className="text-slate-400"> {t('dashboard.security.weeklyAvg')}</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-end">
+        {sparkData.length > 0 && (
+          <Sparkline
+            data={sparkData}
+            color="#7C3AED"
+            width={220}
+            height={36}
+            baseline={baselinePerHour}
+          />
+        )}
+      </div>
+
+      <button
+        onClick={onViewSecurity}
+        className="text-[10px] font-mono text-slate-500 hover:text-brand-purple transition-colors uppercase tracking-widest whitespace-nowrap"
+      >
+        {t('common.viewDetails')}
+      </button>
+    </div>
+  )
+}
+
+// ── Main component ─────────────────────────────────────────────────────────────
+
+export default function Dashboard({ setView }: DashboardProps) {
+  const { t } = useTranslation()
+  const setSelectedAgentId = useUIStore((s) => s.setSelectedAgentId)
+  const { data: servers, isLoading } = useServers()
+
+  // Load health snapshots for all servers in parallel
+  const snapshotQueries = useQueries({
+    queries: (servers ?? []).map((s) => ({
+      queryKey: ['health-snapshot', s.server_id],
+      queryFn: () => serversApi.healthSnapshot(s.server_id),
+      refetchInterval: 30_000,
+    })),
+  })
+
+  const snapshots = (servers ?? []).reduce<Record<string, ServerHealthSnapshot>>((acc, s, i) => {
+    const d = snapshotQueries[i]?.data
+    if (d) acc[s.server_id] = d
+    return acc
+  }, {})
+
+  const fleet: FleetEntry[] = (servers ?? []).map((s) => ({
+    ...s,
+    snapshot: snapshots[s.server_id] ?? null,
+  }))
+
+  const counts = fleet.reduce<Record<string, number>>((acc, s) => {
+    const st = s.snapshot?.state ?? 'quiet'
+    acc[st] = (acc[st] ?? 0) + 1
+    return acc
+  }, {})
+
+  // Focus server: most actionable one with live data
+  const criticalWithData  = fleet.find((s) => s.snapshot?.state === 'critical' && s.snapshot?.cpu?.value != null)
+  const criticalOffline   = fleet.find((s) => s.snapshot?.state === 'critical' && s.snapshot?.cpu?.value == null)
+  const attentionServer   = fleet.find((s) => s.snapshot?.state === 'attention')
+  const focusServer = criticalWithData ?? attentionServer ?? fleet[0]
+
+  const primaryServerId = servers?.find((s) => s.status === 'online')?.server_id ?? ''
+  const focusServerId   = focusServer?.server_id ?? ''
+
+  // Alert events for focus server
+  const { data: eventsData } = useAlertEvents(focusServerId)
+
+  // Security data
+  const { data: sshData }      = useSshEvents(primaryServerId)
+  const { data: hourData }     = useAttackByHour(primaryServerId)
+  const { data: baselineData } = useSshBaseline(primaryServerId)
+
+  // Anomaly scores for focus server (CPU, last 6h = 360min)
+  const { data: anomalyData } = useAnomalyScores(focusServerId, 'cpu_usage_percent', 360, !!focusServerId)
+
+  if (isLoading) {
+    return (
+      <Layout currentView="dashboard" setView={setView} title="Dashboard">
+        <p className="text-slate-400 text-sm">{t('common.loading')}</p>
+      </Layout>
+    )
+  }
+
+  // Derived values
+  const now = Date.now()
+  const firing24h = (eventsData?.events ?? []).filter(
+    (e) => now - new Date(e.triggered_at).getTime() < 86_400_000
+  )
+  const firingNow  = firing24h.filter((e) => e.state === 'FIRING')
+  const totalAnom6h = Object.values(snapshots).reduce((s, h) => s + h.anomalies6h, 0)
+  const mostSevere  = anomalyData?.data.reduce<AnomalyScore | null>(
+    (best, a) => (!best || a.score > best.score) ? a : best, null
+  ) ?? null
+
+  const sshCount   = sshData?.stats.attempts_24h ?? 0
+  const sshBase    = baselineData?.avg_daily ?? 0
+  const sshDelta   = sshBase > 0 ? sshCount / sshBase : 0
+  const hourly     = hourData?.hours ?? []
+
+  // Fleet headline
+  const headlineText = (() => {
+    if ((counts.critical ?? 0) > 0)
+      return t('dashboard.headline.critical', { count: counts.critical })
+    if ((counts.attention ?? 0) > 0)
+      return t('dashboard.headline.attention', { ok: counts.ok ?? 0, count: counts.attention })
+    return t('dashboard.headline.allGood')
+  })()
+
+  const navigate = (serverId: string, view: ViewType = 'server') => {
+    setSelectedAgentId(serverId)
+    setView(view)
+  }
+
+  return (
+    <Layout currentView="dashboard" setView={setView} title="Dashboard">
+      <div className="flex flex-col gap-6">
+
+        {/* Fleet headline + tally */}
+        <div className="flex items-center gap-4">
+          <h1 className="font-bold text-slate-100" style={{ fontSize: 28, fontWeight: 700, letterSpacing: '-0.02em', margin: 0 }}>
+            {headlineText}
+          </h1>
+          <span className="flex-1" />
+          <FleetTallyDot count={counts.ok      ?? 0} state="ok" />
+          <FleetTallyDot count={counts.attention ?? 0} state="attention" />
+          <FleetTallyDot count={counts.critical  ?? 0} state="critical" />
+          <FleetTallyDot count={counts.quiet     ?? 0} state="quiet" />
+        </div>
+
+        {/* Offline callout */}
+        {criticalOffline && criticalOffline !== focusServer && (
+          <div
+            className="glass-card flex items-center gap-3 p-3.5"
+            style={{ borderColor: 'rgba(239,68,68,0.22)', background: 'linear-gradient(180deg, rgba(239,68,68,0.05) 0%, transparent 80%), rgba(30,41,59,0.4)' }}
+          >
+            <WifiOff size={16} style={{ color: '#F87171', flexShrink: 0 }} />
+            <span className="font-mono text-[13px] font-bold text-slate-100">{criticalOffline.server_id}</span>
+            <span className="text-xs text-slate-400">
+              {t('dashboard.offline.message', { time: '2h' })}
+            </span>
+            <span className="flex-1" />
             <button
-              onClick={() => setView('infrastructure')}
-              className="text-[10px] text-slate-500 hover:text-brand-purple transition-colors uppercase tracking-widest font-mono"
+              onClick={() => navigate(criticalOffline.server_id)}
+              className="text-[10px] font-mono text-slate-400 hover:text-brand-purple transition-colors uppercase tracking-widest"
             >
-              Ver todos
+              {t('common.investigate')}
             </button>
           </div>
+        )}
 
-          {isLoading && <p className="text-slate-500 text-sm">Carregando...</p>}
+        {/* Focus hero */}
+        {focusServer && (
+          <FocusHero
+            server={focusServer}
+            snapshot={focusServer.snapshot}
+            onOpen={() => navigate(focusServer.server_id)}
+          />
+        )}
 
-          <div className="space-y-2">
-            {servers?.map((server) => (
+        {/* 2-column: incidents + anomalies */}
+        <div className="grid gap-6" style={{ gridTemplateColumns: '1.4fr 1fr' }}>
+          <IncidentsCard
+            events={firing24h}
+            firingNow={firingNow}
+            onViewAlerts={() => setView('alerts')}
+          />
+          <AnomaliesCard
+            count6h={totalAnom6h}
+            mostSevere={mostSevere}
+            onViewServer={() => focusServer && navigate(focusServer.server_id)}
+          />
+        </div>
+
+        {/* Fleet strip */}
+        {fleet.length > 0 && (
+          <section>
+            <div className="flex items-baseline justify-between mb-3">
+              <h2 className="text-sm font-bold text-slate-300">
+                {t('dashboard.fleet', { count: fleet.length })}
+              </h2>
               <button
-                key={server.server_id}
-                onClick={() => {
-                  setSelectedAgentId(server.server_id)
-                  setView('server')
-                }}
-                className="w-full flex items-center justify-between p-3 bg-white/5 hover:bg-white/10 border border-white/5 rounded-lg transition-all text-left"
+                onClick={() => setView('infrastructure')}
+                className="text-[10px] font-mono text-slate-500 hover:text-brand-purple transition-colors uppercase tracking-widest"
               >
-                <div className="flex items-center gap-3">
-                  <span className={`w-2 h-2 rounded-full flex-shrink-0 ${
-                    server.status === 'online'  ? 'bg-emerald-400 shadow-[0_0_6px_rgba(52,211,153,0.8)]'
-                    : server.status === 'offline' ? 'bg-red-500'
-                    : 'bg-slate-500'
-                  }`} />
-                  <span className="text-sm font-mono">{server.server_id}</span>
-                </div>
-                <span className={`text-xs capitalize ${
-                  server.status === 'online'  ? 'text-emerald-400'
-                  : server.status === 'offline' ? 'text-red-400'
-                  : 'text-slate-400'
-                }`}>
-                  {server.status}
-                </span>
+                {t('common.viewMap')}
               </button>
-            ))}
-          </div>
-        </section>
+            </div>
+            <div className="grid gap-3" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))' }}>
+              {fleet.map((s) => (
+                <FleetTile
+                  key={s.server_id}
+                  server={s}
+                  onClick={() => navigate(s.server_id)}
+                />
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Security pulse */}
+        {sshCount > 0 && (
+          <SecurityPulseCard
+            sshCount={sshCount}
+            baseline={sshBase}
+            delta={sshDelta}
+            hourly={hourly}
+            onViewSecurity={() => setView('security')}
+          />
+        )}
+
       </div>
     </Layout>
   )
 }
-
-export default Dashboard

--- a/frontend/src/components/Infrastructure.tsx
+++ b/frontend/src/components/Infrastructure.tsx
@@ -1,60 +1,46 @@
-import { Server, Network, Clock, Package, CheckCircle, XCircle, HelpCircle, RefreshCw } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { useQueries } from '@tanstack/react-query'
+import { Server, Package, CheckCircle, XCircle, HelpCircle, RefreshCw, WifiOff, TrendingUp, TrendingDown, Minus } from 'lucide-react'
 import Layout from './Layout'
 import type { ViewType } from '../App'
+import { HealthScore, TrendBar } from './primitives'
+import type { HealthState } from './primitives'
+import type { ServerHealthSnapshot } from '../services/api'
+import { serversApi } from '../services/api'
 import { useServers } from '../hooks/useServers'
-import { useUIStore } from '../store/uiStore'
 import { useInventory } from '../hooks/useInventory'
+import { useUIStore } from '../store/uiStore'
 import type { ServerStatus } from '../types/server'
-import type { RuntimeEntry } from '../services/api'
 
 interface InfrastructureProps {
   setView: (view: ViewType) => void
 }
 
-const statusDot: Record<ServerStatus['status'], string> = {
-  online:  'bg-emerald-400 shadow-[0_0_8px_rgba(52,211,153,0.8)]',
-  offline: 'bg-red-500',
-  unknown: 'bg-slate-500',
-}
+// ── Inventory table (unchanged from v1 — services + runtimes per server) ─────
 
-const statusBar: Record<ServerStatus['status'], string> = {
-  online:  'bg-emerald-400',
-  offline: 'bg-red-500',
-  unknown: 'bg-slate-600',
-}
-
-function timeAgo(iso: string | null): string {
-  if (!iso) return '—'
-  const diff = Math.floor((Date.now() - new Date(iso).getTime()) / 1000)
-  if (diff < 60) return `${diff}s atrás`
-  if (diff < 3600) return `${Math.floor(diff / 60)}m atrás`
-  return `${Math.floor(diff / 3600)}h atrás`
+function ServiceStatus({ status }: { status: string }) {
+  if (status === 'active')   return <CheckCircle className="w-3.5 h-3.5 text-brand-neon" />
+  if (status === 'inactive' || status === 'failed')
+                             return <XCircle className="w-3.5 h-3.5 text-red-400" />
+  return <HelpCircle className="w-3.5 h-3.5 text-slate-500" />
 }
 
 function uptimeSince(iso: string | null): string {
   if (!iso) return '—'
   const diff = Math.floor((Date.now() - new Date(iso).getTime()) / 1000)
-  if (diff < 3600) return `${Math.floor(diff / 60)}m`
+  if (diff < 3600)  return `${Math.floor(diff / 60)}m`
   if (diff < 86400) return `${Math.floor(diff / 3600)}h`
   return `${Math.floor(diff / 86400)}d`
-}
-
-function ServiceStatus({ status }: { status: string }) {
-  if (status === 'active')
-    return <CheckCircle className="w-3.5 h-3.5 text-brand-neon" />
-  if (status === 'inactive' || status === 'failed')
-    return <XCircle className="w-3.5 h-3.5 text-red-400" />
-  return <HelpCircle className="w-3.5 h-3.5 text-slate-500" />
 }
 
 function InventoryTable({ serverId }: { serverId: string }) {
   const { data, isFetching, isError } = useInventory(serverId)
 
-  if (isError) return <p className="text-xs text-red-400 mt-4">Erro ao carregar inventário.</p>
-  if (!data) return <p className="text-xs text-slate-500 mt-4">Carregando inventário...</p>
+  if (isError) return <p className="text-xs text-red-400 mt-4">Error loading inventory.</p>
+  if (!data)   return <p className="text-xs text-slate-500 mt-4">Loading inventory…</p>
 
-  const daemons = data.inventory.filter((e) => e.status !== 'n/a' && e.status !== 'unknown')
-  const runtimes = data.inventory.filter((e) => e.status === 'n/a' || e.status === 'unknown')
+  const daemons  = data.inventory.filter((e) => e.status !== 'n/a' && e.status !== 'unknown')
+  const runtimes = data.inventory.filter((e) => e.status === 'n/a'  || e.status === 'unknown')
 
   return (
     <div className="mt-6 space-y-6">
@@ -63,22 +49,38 @@ function InventoryTable({ serverId }: { serverId: string }) {
           <div className="px-4 py-3 border-b border-white/5 bg-white/5 flex items-center justify-between">
             <h3 className="text-xs font-bold uppercase tracking-widest text-slate-400 flex items-center gap-2">
               <Server className="w-3.5 h-3.5 text-brand-purple" />
-              Serviços
+              Services
             </h3>
             {isFetching && <RefreshCw className="w-3 h-3 animate-spin text-slate-500" />}
           </div>
           <table className="w-full text-left">
             <thead className="text-[10px] text-slate-500 uppercase tracking-widest bg-brand-dark/20">
               <tr>
-                <th className="px-4 py-2 font-medium">Serviço</th>
-                <th className="px-4 py-2 font-medium">Versão</th>
+                <th className="px-4 py-2 font-medium">Service</th>
+                <th className="px-4 py-2 font-medium">Version</th>
                 <th className="px-4 py-2 font-medium">Status</th>
                 <th className="px-4 py-2 font-medium">Uptime</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-white/5">
               {daemons.map((e) => (
-                <ServiceRow key={e.name} entry={e} />
+                <tr key={e.name} className="hover:bg-white/5 transition-colors">
+                  <td className="px-4 py-2.5 text-sm font-medium text-slate-200">{e.name}</td>
+                  <td className="px-4 py-2.5 font-mono text-xs text-slate-400">
+                    {e.version === 'not found' ? <span className="text-slate-600">not installed</span> : e.version}
+                  </td>
+                  <td className="px-4 py-2.5">
+                    <div className="flex items-center gap-1.5">
+                      <ServiceStatus status={e.status} />
+                      <span className={`text-xs ${e.status === 'active' ? 'text-brand-neon' : e.status === 'failed' ? 'text-red-400' : 'text-slate-500'}`}>
+                        {e.status}
+                      </span>
+                    </div>
+                  </td>
+                  <td className="px-4 py-2.5 font-mono text-xs text-slate-500">
+                    {uptimeSince(e.uptime_since)}
+                  </td>
+                </tr>
               ))}
             </tbody>
           </table>
@@ -97,7 +99,7 @@ function InventoryTable({ serverId }: { serverId: string }) {
             <thead className="text-[10px] text-slate-500 uppercase tracking-widest bg-brand-dark/20">
               <tr>
                 <th className="px-4 py-2 font-medium">Runtime</th>
-                <th className="px-4 py-2 font-medium">Versão</th>
+                <th className="px-4 py-2 font-medium">Version</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-white/5">
@@ -105,9 +107,7 @@ function InventoryTable({ serverId }: { serverId: string }) {
                 <tr key={e.name} className="hover:bg-white/5 transition-colors">
                   <td className="px-4 py-2.5 text-sm font-medium text-slate-200">{e.name}</td>
                   <td className="px-4 py-2.5 font-mono text-xs text-slate-400">
-                    {e.version === 'not found'
-                      ? <span className="text-slate-600">não instalado</span>
-                      : e.version}
+                    {e.version === 'not found' ? <span className="text-slate-600">not installed</span> : e.version}
                   </td>
                 </tr>
               ))}
@@ -119,38 +119,163 @@ function InventoryTable({ serverId }: { serverId: string }) {
   )
 }
 
-function ServiceRow({ entry: e }: { entry: RuntimeEntry }) {
+// ── Snapshot card ─────────────────────────────────────────────────────────────
+
+function MeterRow({
+  label,
+  metric,
+  color,
+}: {
+  label: string
+  metric: ServerHealthSnapshot['cpu'] | null | undefined
+  color: string
+}) {
+  if (!metric) return null
+  const over = metric.value != null && metric.value >= metric.threshold * 0.9
+  const TrendIcon = metric.trend === 'up' ? TrendingUp : metric.trend === 'down' ? TrendingDown : Minus
+  const trendColor = metric.trend === 'up' && metric.baseline != null && metric.value != null && metric.value > metric.baseline * 1.05
+    ? '#F87171' : metric.trend === 'down' ? '#34D399' : '#64748B'
+
   return (
-    <tr className="hover:bg-white/5 transition-colors">
-      <td className="px-4 py-2.5 text-sm font-medium text-slate-200">{e.name}</td>
-      <td className="px-4 py-2.5 font-mono text-xs text-slate-400">
-        {e.version === 'not found'
-          ? <span className="text-slate-600">não instalado</span>
-          : e.version}
-      </td>
-      <td className="px-4 py-2.5">
-        <div className="flex items-center gap-1.5">
-          <ServiceStatus status={e.status} />
-          <span className={`text-xs ${
-            e.status === 'active' ? 'text-brand-neon'
-            : e.status === 'failed' ? 'text-red-400'
-            : 'text-slate-500'
-          }`}>
-            {e.status}
-          </span>
-        </div>
-      </td>
-      <td className="px-4 py-2.5 font-mono text-xs text-slate-500">
-        {uptimeSince(e.uptime_since)}
-      </td>
-    </tr>
+    <div>
+      <div className="grid items-center gap-x-2" style={{ gridTemplateColumns: '40px 1fr 14px auto' }}>
+        <span className="text-[10px] font-bold uppercase tracking-widest text-slate-500">{label}</span>
+        <TrendBar
+          value={metric.value ?? 0}
+          threshold={metric.threshold}
+          baseline={metric.baseline ?? undefined}
+          color={color}
+          height={5}
+        />
+        <TrendIcon size={11} style={{ color: trendColor }} />
+        <span
+          className="font-mono text-xs font-bold text-right"
+          style={{ color: over ? '#F87171' : 'var(--tw-text-opacity, #e2e8f0)', minWidth: 36 }}
+        >
+          {metric.value ?? '—'}%
+        </span>
+      </div>
+      {metric.projection && (
+        <div className="text-[10px] text-amber-400 ml-11 mt-0.5">↗ {metric.projection}</div>
+      )}
+    </div>
   )
 }
 
+function SnapshotCard({
+  server,
+  snapshot,
+  onClick,
+}: {
+  server: ServerStatus
+  snapshot: ServerHealthSnapshot | null
+  onClick: () => void
+}) {
+  const { t } = useTranslation()
+  const offline = snapshot == null || snapshot.cpu?.value == null
+  const state = (snapshot?.state ?? 'quiet') as HealthState
+  const stateColor = { ok: '#34D399', attention: '#F59E0B', critical: '#F87171', quiet: '#94A3B8' }[state]
+
+  return (
+    <button
+      onClick={onClick}
+      className="glass-card p-5 text-left cursor-pointer relative overflow-hidden w-full"
+      style={{ transition: 'all 0.15s ease' }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.borderColor = 'rgba(124,58,237,0.40)'
+        e.currentTarget.style.boxShadow = '0 0 20px rgba(124,58,237,0.10)'
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.borderColor = ''
+        e.currentTarget.style.boxShadow = ''
+      }}
+    >
+      {/* State stripe */}
+      <div style={{ position: 'absolute', top: 0, right: 0, width: 3, height: '100%', background: stateColor }} />
+
+      {/* Header */}
+      <div className="flex items-center gap-2.5 mb-4">
+        <div className="w-8 h-8 rounded-lg bg-brand-slate flex items-center justify-center flex-shrink-0">
+          <Server size={16} className="text-brand-purple" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="font-mono text-sm font-bold text-slate-100 truncate">{server.server_id}</div>
+          <div className="text-[10px] text-slate-500 uppercase">{server.agent_version ?? 'unknown'}</div>
+        </div>
+        <HealthScore state={state} size="sm" />
+      </div>
+
+      {/* Headline */}
+      {snapshot?.headline && (
+        <p className="text-xs text-slate-300 mb-3 leading-relaxed">{snapshot.headline}</p>
+      )}
+
+      {/* Metrics */}
+      {offline ? (
+        <div className="flex items-center gap-2 py-3 text-xs text-slate-500">
+          <WifiOff size={14} />
+          <span>{t('infrastructure.noMetrics')}</span>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          <MeterRow label={t('health.metrics.cpu')}    metric={snapshot?.cpu}    color="#39FF14" />
+          <MeterRow label={t('health.metrics.memory').slice(0, 3)} metric={snapshot?.memory} color="#7C3AED" />
+          <MeterRow label={t('health.metrics.disk')}   metric={snapshot?.disk}   color="#F59E0B" />
+        </div>
+      )}
+
+      {/* Footer */}
+      <div className="flex items-center justify-between mt-4 pt-3 border-t border-white/5">
+        <div className="flex items-center gap-1">
+          {(snapshot?.critical_services ?? []).slice(0, 5).map((svc) => (
+            <div
+              key={svc.name}
+              title={`${svc.name} · ${svc.ok ? 'active' : 'failed'}`}
+              style={{
+                width: 6, height: 6, borderRadius: '50%',
+                background: svc.ok ? '#39FF14' : '#F87171',
+                boxShadow: svc.ok ? '0 0 4px rgba(57,255,20,0.5)' : 'none',
+              }}
+            />
+          ))}
+          <span className="font-mono text-[10px] text-slate-500 ml-1">
+            {t('infrastructure.services', { count: (snapshot?.critical_services ?? []).length })}
+          </span>
+        </div>
+        {(snapshot?.anomalies6h ?? 0) > 0 ? (
+          <span className="font-mono text-[10px] text-amber-400">
+            {t('health.anomalies6h', { count: snapshot!.anomalies6h })}
+          </span>
+        ) : (
+          <span className="font-mono text-[10px] text-slate-600">0 anomalies</span>
+        )}
+      </div>
+    </button>
+  )
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
 export default function Infrastructure({ setView }: InfrastructureProps) {
+  const { t } = useTranslation()
   const { data: servers, isLoading, isError } = useServers()
   const selectedAgentId = useUIStore((s) => s.selectedAgentId)
   const setSelectedAgentId = useUIStore((s) => s.setSelectedAgentId)
+
+  // Health snapshots for all servers in parallel
+  const snapshotQueries = useQueries({
+    queries: (servers ?? []).map((s) => ({
+      queryKey: ['health-snapshot', s.server_id],
+      queryFn: () => serversApi.healthSnapshot(s.server_id),
+      refetchInterval: 30_000,
+    })),
+  })
+
+  const snapshots = (servers ?? []).reduce<Record<string, ServerHealthSnapshot>>((acc, s, i) => {
+    const d = snapshotQueries[i]?.data
+    if (d) acc[s.server_id] = d
+    return acc
+  }, {})
 
   const serverId = selectedAgentId
     ?? servers?.find((s) => s.status === 'online')?.server_id
@@ -163,64 +288,30 @@ export default function Infrastructure({ setView }: InfrastructureProps) {
   }
 
   return (
-    <Layout currentView="infrastructure" setView={setView} title="Mapa de Servidores">
-      <div className="space-y-4 mb-8">
-        <h2 className="text-xl font-bold flex items-center gap-2">
-          <Network className="w-5 h-5 text-brand-purple" />
-          Servidores Monitorados
-        </h2>
-        <p className="text-slate-400 text-sm">
-          Status em tempo real de todos os agentes Maestro registrados.
-        </p>
+    <Layout currentView="infrastructure" setView={setView} title={t('infrastructure.title')}>
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold text-slate-100 mb-1.5">{t('infrastructure.title')}</h1>
+        <p className="text-slate-400 text-sm">{t('infrastructure.subtitle')}</p>
       </div>
 
-      {isLoading && <p className="text-slate-400 text-sm">Carregando servidores...</p>}
-      {isError && <p className="text-red-400 text-sm">Erro ao carregar servidores.</p>}
+      {isLoading && <p className="text-slate-400 text-sm">{t('common.loading')}</p>}
+      {isError   && <p className="text-red-400 text-sm">Error loading servers.</p>}
 
       {servers && servers.length === 0 && (
         <div className="glass-card p-10 text-center">
           <Server className="w-10 h-10 text-slate-600 mx-auto mb-3" />
-          <p className="text-slate-500 text-sm">Nenhum servidor registrado ainda.</p>
+          <p className="text-slate-500 text-sm">No servers registered yet.</p>
         </div>
       )}
 
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+      <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))' }}>
         {servers?.map((server) => (
-          <button
+          <SnapshotCard
             key={server.server_id}
+            server={server}
+            snapshot={snapshots[server.server_id] ?? null}
             onClick={() => handleSelect(server.server_id)}
-            className="glass-card p-5 relative overflow-hidden text-left group hover:border-brand-purple/40 transition-all"
-          >
-            <div className={`absolute top-0 right-0 w-1 h-full ${statusBar[server.status]}`} />
-
-            <div className="flex items-center gap-3 mb-4">
-              <div className="p-2 bg-brand-slate rounded-lg">
-                <Server className="w-4 h-4 text-brand-purple" />
-              </div>
-              <div className="min-w-0">
-                <h3 className="text-sm font-bold font-mono tracking-tight truncate">{server.server_id}</h3>
-                <span className="text-[10px] text-slate-500 uppercase">
-                  {server.agent_version ?? 'versão desconhecida'}
-                </span>
-              </div>
-            </div>
-
-            <div className="flex items-center gap-2 mt-4">
-              <span className={`w-2 h-2 rounded-full flex-shrink-0 ${statusDot[server.status]}`} />
-              <span className={`text-xs font-semibold capitalize ${
-                server.status === 'online' ? 'text-emerald-400'
-                : server.status === 'offline' ? 'text-red-400'
-                : 'text-slate-400'
-              }`}>
-                {server.status}
-              </span>
-            </div>
-
-            <div className="mt-3 pt-3 border-t border-white/5 flex items-center gap-1.5 font-mono text-[9px] text-slate-500 opacity-70 group-hover:opacity-100 transition-opacity">
-              <Clock className="w-3 h-3" />
-              <span>{timeAgo(server.last_seen)}</span>
-            </div>
-          </button>
+          />
         ))}
       </div>
 

--- a/frontend/src/components/LogsExplorer.tsx
+++ b/frontend/src/components/LogsExplorer.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Download, Filter, Terminal, Wifi, WifiOff, RefreshCw } from 'lucide-react'
 import Layout from './Layout'
 import type { ViewType } from '../App'
@@ -59,7 +60,7 @@ function LogStream({ serverId, logFile, initialLines, filter }: LogStreamProps) 
             className="flex gap-3 px-3 py-0.5 hover:bg-white/3 transition-colors group"
           >
             <span className="text-slate-600 shrink-0 text-xs pt-0.5">
-              {new Date(l.timestamp).toLocaleTimeString('pt-BR', { hour12: false })}
+              {new Date(l.timestamp).toLocaleTimeString(undefined, { hour12: false })}
             </span>
             <span className={`text-xs font-mono break-all ${lineColor(l.line)}`}>{l.line}</span>
           </div>
@@ -70,6 +71,7 @@ function LogStream({ serverId, logFile, initialLines, filter }: LogStreamProps) 
 }
 
 export default function LogsExplorer({ setView }: LogsExplorerProps) {
+  const { t } = useTranslation()
   const [selectedServer, setSelectedServer] = useState('')
   const [selectedFiles, setSelectedFiles] = useState<string[]>([])
   const [filter, setFilter] = useState('')
@@ -120,13 +122,13 @@ export default function LogsExplorer({ setView }: LogsExplorerProps) {
   const hasSelection = selectedFiles.length > 0
 
   return (
-    <Layout currentView="logs" setView={setView} title="Log Explorer">
+    <Layout currentView="logs" setView={setView} title={t('logs.title')}>
       <div className="flex gap-4 h-[calc(100vh-10rem)]">
 
         {/* Sidebar: server + file selector */}
         <div className="w-56 shrink-0 flex flex-col gap-3">
           <div className="glass-card p-3">
-            <p className="text-xs text-slate-500 uppercase tracking-widest mb-2">Servidor</p>
+            <p className="text-xs text-slate-500 uppercase tracking-widest mb-2">{t('logs.server')}</p>
             <select
               value={selectedServer}
               onChange={(e) => setSelectedServer(e.target.value)}
@@ -141,10 +143,10 @@ export default function LogsExplorer({ setView }: LogsExplorerProps) {
           </div>
 
           <div className="glass-card p-3 flex-1 overflow-y-auto">
-            <p className="text-xs text-slate-500 uppercase tracking-widest mb-2">Arquivos</p>
+            <p className="text-xs text-slate-500 uppercase tracking-widest mb-2">{t('logs.files')}</p>
             {availableFiles.length === 0 && (
               <p className="text-xs text-slate-600 italic">
-                {selectedServer ? 'Nenhum log disponível' : 'Selecione um servidor'}
+                {selectedServer ? t('logs.noLogsAvailable') : t('logs.selectServer')}
               </p>
             )}
             <div className="space-y-1">
@@ -176,7 +178,7 @@ export default function LogsExplorer({ setView }: LogsExplorerProps) {
               <Filter className="w-3.5 h-3.5 absolute left-2.5 top-1/2 -translate-y-1/2 text-slate-500" />
               <input
                 type="text"
-                placeholder="Filtrar linhas..."
+                placeholder={t('logs.filterPlaceholder')}
                 value={filter}
                 onChange={(e) => setFilter(e.target.value)}
                 className="w-full bg-brand-dark border border-white/10 rounded pl-8 pr-3 py-1.5 text-xs font-mono focus:outline-none focus:border-brand-purple/50"
@@ -188,7 +190,7 @@ export default function LogsExplorer({ setView }: LogsExplorerProps) {
               className="flex items-center gap-1.5 text-xs text-slate-400 hover:text-white disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
             >
               <Download className="w-3.5 h-3.5" />
-              Exportar
+              {t('logs.export')}
             </button>
           </div>
 
@@ -198,7 +200,7 @@ export default function LogsExplorer({ setView }: LogsExplorerProps) {
               <div className="h-full flex items-center justify-center text-slate-600">
                 <div className="text-center">
                   <Terminal className="w-8 h-8 mx-auto mb-2 opacity-30" />
-                  <p>Selecione um ou mais arquivos de log</p>
+                  <p>{t('logs.selectFiles')}</p>
                 </div>
               </div>
             ) : (
@@ -224,8 +226,8 @@ export default function LogsExplorer({ setView }: LogsExplorerProps) {
             <Terminal className="w-3 h-3 text-brand-neon animate-pulse" />
             <span className="text-xs font-mono text-brand-neon tracking-widest uppercase">
               {hasSelection
-                ? `Watching ${selectedFiles.length} file(s) on ${selectedServer}`
-                : 'Ready'}
+                ? t('logs.watchingFiles', { count: selectedFiles.length, server: selectedServer })
+                : t('logs.ready')}
             </span>
           </div>
         </div>

--- a/frontend/src/components/Security.tsx
+++ b/frontend/src/components/Security.tsx
@@ -1,13 +1,246 @@
-import { ShieldAlert, ShieldCheck, Eye, Lock, RefreshCw } from 'lucide-react'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ChevronDown, ChevronUp, MapPin, Users, ShieldCheck, Shield } from 'lucide-react'
 import Layout from './Layout'
 import type { ViewType } from '../App'
+import { HealthScore } from './primitives'
+import type { HealthState } from './primitives'
 import { useServers } from '../hooks/useServers'
 import { useSshEvents } from '../hooks/useSecurity'
+import { useAttackers, useAttackByHour, useSshBaseline } from '../hooks/useMetrics'
+import { useUIStore } from '../store/uiStore'
 import type { SshEvent } from '../services/api'
 
 interface SecurityProps {
   setView: (view: ViewType) => void
 }
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function relative(iso: string): string {
+  const diff = Math.floor((Date.now() - new Date(iso).getTime()) / 1000)
+  if (diff < 60)    return `${diff}s ago`
+  if (diff < 3600)  return `${Math.floor(diff / 60)}min ago`
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
+  return `${Math.floor(diff / 86400)}d ago`
+}
+
+// ── Hourly bar chart ──────────────────────────────────────────────────────────
+
+function HourlyBars({ hourly, baselinePerHour, color }: { hourly: { hour: number; count: number }[], baselinePerHour: number, color: string }) {
+  const max = Math.max(...hourly.map((h) => h.count), baselinePerHour, 1)
+  const basePct = (baselinePerHour / max) * 100
+
+  return (
+    <div style={{ position: 'relative', height: 80, display: 'flex', alignItems: 'flex-end', gap: 3 }}>
+      {hourly.map((h, i) => {
+        const pct = (h.count / max) * 100
+        const over = h.count > baselinePerHour * 2
+        return (
+          <div
+            key={i}
+            title={`${h.hour}h · ${h.count} attempts`}
+            style={{
+              flex: 1,
+              height: `${Math.max(pct, 1)}%`,
+              background: over ? '#F87171' : color,
+              opacity: over ? 1 : 0.7,
+              borderRadius: '2px 2px 0 0',
+              minHeight: 2,
+            }}
+          />
+        )
+      })}
+      {/* Baseline line */}
+      <div style={{
+        position: 'absolute', left: 0, right: 0,
+        bottom: `${basePct}%`,
+        height: 1,
+        background: 'rgba(255,255,255,0.35)',
+        pointerEvents: 'none',
+      }} />
+    </div>
+  )
+}
+
+// ── Threat hero ───────────────────────────────────────────────────────────────
+
+function ThreatHero({
+  today,
+  baseline,
+  ratio,
+  state,
+  hourly,
+  peakHour,
+}: {
+  today: number
+  baseline: number
+  ratio: number
+  state: HealthState
+  hourly: { hour: number; count: number }[]
+  peakHour: { hour: number; count: number }
+}) {
+  const { t } = useTranslation()
+  const conf = {
+    ok:        { fg: '#34D399', soft: 'rgba(52,211,153,0.06)', border: 'rgba(52,211,153,0.20)', label: 'normal' },
+    attention: { fg: '#F59E0B', soft: 'rgba(245,158,11,0.06)', border: 'rgba(245,158,11,0.22)', label: 'elevated' },
+    critical:  { fg: '#F87171', soft: 'rgba(239,68,68,0.06)',  border: 'rgba(239,68,68,0.22)',  label: 'critical' },
+    quiet:     { fg: '#94A3B8', soft: 'rgba(148,163,184,0.06)', border: 'rgba(148,163,184,0.20)', label: 'normal' },
+  }[state]
+
+  const peakLabel = `${String(peakHour.hour).padStart(2, '0')}:00–${String(peakHour.hour + 1).padStart(2, '0')}:00`
+
+  return (
+    <div
+      className="glass-card"
+      style={{
+        padding: 24, position: 'relative', overflow: 'hidden',
+        borderColor: conf.border,
+        background: `linear-gradient(180deg, ${conf.soft} 0%, transparent 50%), rgba(30,41,59,0.4)`,
+      }}
+    >
+      <div className="grid items-center gap-8" style={{ gridTemplateColumns: 'auto 1fr' }}>
+        <div>
+          <div className="flex items-center gap-2 mb-2.5">
+            <span className="text-[10px] font-mono font-bold uppercase tracking-widest" style={{ color: conf.fg }}>
+              {t('security.ssh24h')}
+            </span>
+            <HealthScore state={state} size="sm" />
+          </div>
+          <div className="flex items-baseline gap-3">
+            <span className="font-mono font-bold text-slate-100 tabular-nums" style={{ fontSize: 44, letterSpacing: '-0.02em', lineHeight: 1 }}>
+              {today.toLocaleString()}
+            </span>
+            <span className="text-sm text-slate-400">{t('security.attempts')}</span>
+          </div>
+          <div className="text-sm text-slate-300 mt-2.5" style={{ lineHeight: 1.55, maxWidth: 360 }}>
+            {t('security.weeklyAvg7d')}: <span className="font-mono">{baseline.toLocaleString()}</span>
+            {' — '}
+            <span className="font-mono font-bold" style={{ color: conf.fg }}>{ratio.toFixed(1)}× {conf.label}</span>
+            <br />
+            {t('security.peakAt')} <span className="font-mono">{peakLabel}</span>
+            {' with '}<span className="font-mono">{peakHour.count}</span>{' attempts.'}
+          </div>
+        </div>
+
+        <div>
+          <HourlyBars hourly={hourly} baselinePerHour={baseline / 24} color={conf.fg} />
+          <div className="flex justify-between mt-1.5 font-mono text-[9px] text-slate-600">
+            <span>00h</span><span>06h</span><span>12h</span><span>18h</span><span>24h</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Attacker row ──────────────────────────────────────────────────────────────
+
+function AttackerRow({ attacker }: { attacker: { ip: string; attempts: number; users: string[]; last_seen: string; blocked: boolean } }) {
+  const [expanded, setExpanded] = useState(false)
+  const { t } = useTranslation()
+  const sev = attacker.attempts >= 500 ? 'critical' : attacker.attempts >= 100 ? 'attention' : 'ok'
+  const sevColor = { ok: '#34D399', attention: '#F59E0B', critical: '#F87171' }[sev]
+
+  return (
+    <div className="border-t border-white/5">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full p-3.5 text-left transition-colors hover:bg-white/3"
+        style={{ display: 'grid', gridTemplateColumns: 'auto 1fr auto auto auto auto', gap: 16, alignItems: 'center' }}
+      >
+        <span style={{ width: 8, height: 8, borderRadius: '50%', background: sevColor, flexShrink: 0, boxShadow: sev === 'ok' ? `0 0 6px ${sevColor}88` : 'none' }} />
+        <div>
+          <div className="font-mono text-[13px] font-bold text-slate-100">{attacker.ip}</div>
+          <div className="text-[11px] text-slate-500 mt-0.5 flex items-center gap-1">
+            <MapPin size={10} />
+            <span className="font-mono">{attacker.ip.startsWith('10.') || attacker.ip.startsWith('192.168.') ? 'private' : 'public'}</span>
+            <span className="mx-1.5 text-slate-700">·</span>
+            <span>{relative(attacker.last_seen)}</span>
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="font-mono text-base font-bold" style={{ color: sevColor }}>{attacker.attempts.toLocaleString()}</div>
+          <div className="text-[10px] text-slate-500">{t('security.attackers.attempts', { count: attacker.attempts }).split(' ')[0]}</div>
+        </div>
+        <div className="text-right">
+          <div className="font-mono text-sm text-slate-300">{attacker.users.length}</div>
+          <div className="text-[10px] text-slate-500">users</div>
+        </div>
+        {attacker.blocked
+          ? <span className="text-[10px] px-2 py-0.5 rounded-full border bg-brand-neon/10 text-brand-neon border-brand-neon/20 font-mono font-bold">BLOCKED</span>
+          : <span className="text-[10px] px-2 py-0.5 rounded-full border bg-orange-500/10 text-orange-400 border-orange-500/20 font-mono font-bold">ACTIVE</span>
+        }
+        {expanded ? <ChevronUp size={14} className="text-slate-500" /> : <ChevronDown size={14} className="text-slate-500" />}
+      </button>
+
+      {expanded && (
+        <div className="px-3.5 pb-4 pl-10 flex flex-col gap-2">
+          <div className="text-xs text-slate-400">{t('security.attackers.users')}</div>
+          <div className="flex flex-wrap gap-1.5">
+            {attacker.users.map((u) => (
+              <span key={u} className="px-2 py-0.5 rounded text-xs font-mono text-slate-300 bg-brand-slate border border-white/10">
+                {u}
+              </span>
+            ))}
+          </div>
+          <div className="mt-1 text-[11px] font-mono text-slate-500">
+            target: {attacker.users[0]} · {attacker.attempts} attacks · status: {attacker.blocked ? t('security.attackers.blockedByFail2ban') : t('security.attackers.underObservation')}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Session summary side card ─────────────────────────────────────────────────
+
+function SessionSummaryCard({ stats }: { stats: { attempts_1h: number; attempts_24h: number; unique_ips_24h: number; top_target: string | null } | undefined }) {
+  const { t } = useTranslation()
+  const Row = ({ k, v, mono = false, color }: { k: string; v: React.ReactNode; mono?: boolean; color?: string }) => (
+    <div className="flex justify-between items-center text-xs">
+      <span className="text-slate-400">{k}</span>
+      <span className={`font-bold ${mono ? 'font-mono' : ''}`} style={{ color }}>{v}</span>
+    </div>
+  )
+  return (
+    <div className="glass-card p-5">
+      <h3 className="text-sm font-bold flex items-center gap-2 mb-4">
+        <ShieldCheck size={14} className="text-brand-purple" />
+        {t('security.session.title')}
+      </h3>
+      <div className="flex flex-col gap-3">
+        <Row k={t('security.session.attempts1h')}  v={stats?.attempts_1h  ?? '—'} color="#F87171" mono />
+        <Row k={t('security.session.attempts24h')} v={stats?.attempts_24h?.toLocaleString() ?? '—'} color="var(--tw-text-opacity)" mono />
+        <Row k={t('security.session.uniqueIps')}   v={stats?.unique_ips_24h ?? '—'} mono />
+        <Row k={t('security.session.topTarget')}   v={stats?.top_target ?? '—'} color="#7C3AED" mono />
+      </div>
+    </div>
+  )
+}
+
+function Fail2BanCard() {
+  const { t } = useTranslation()
+  return (
+    <div className="glass-card p-5">
+      <h3 className="text-sm font-bold flex items-center gap-2 mb-4">
+        <Shield size={14} className="text-brand-purple" />
+        {t('security.fail2ban.title')}
+      </h3>
+      <div className="flex items-center gap-2.5 p-2.5 rounded-lg bg-brand-neon/5 border border-brand-neon/20">
+        <span className="w-2 h-2 rounded-full bg-brand-neon animate-pulse shadow-[0_0_8px_rgba(57,255,20,0.6)]" />
+        <span className="font-mono text-xs text-brand-neon font-bold uppercase tracking-widest">active</span>
+        <span className="flex-1" />
+        <span className="text-[11px] text-slate-500 font-mono">v1.0.2</span>
+      </div>
+      <div className="text-xs text-slate-400 mt-2.5" style={{ lineHeight: 1.6 }}>
+        {t('security.fail2ban.bansLast24h', { count: 4 })} Ban window: <span className="font-mono">10min</span>, max retries: <span className="font-mono">3</span>.
+      </div>
+    </div>
+  )
+}
+
+// ── Audit log (kept from v1) ──────────────────────────────────────────────────
 
 const resultStyle: Record<string, string> = {
   Blocked: 'bg-red-500/10 text-red-400 border-red-500/20',
@@ -16,21 +249,14 @@ const resultStyle: Record<string, string> = {
 }
 
 function EventRow({ ev }: { ev: SshEvent }) {
-  const time = new Date(ev.timestamp).toLocaleTimeString('pt-BR', {
-    hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
-  })
+  const time = new Date(ev.timestamp).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })
   return (
     <tr className="hover:bg-white/5 transition-colors">
-      <td className="px-4 py-3 text-xs font-mono text-slate-500 shrink-0">{time}</td>
-      <td className="px-4 py-3">
-        <div className="flex items-center gap-2">
-          <Lock className="w-3 h-3 text-brand-purple opacity-50 shrink-0" />
-          <span className="text-sm font-medium">{ev.action}</span>
-        </div>
-      </td>
-      <td className="px-4 py-3 font-mono text-xs text-slate-400">{ev.source_ip}</td>
-      <td className="px-4 py-3 font-mono text-xs text-slate-300">{ev.username}</td>
-      <td className="px-4 py-3">
+      <td className="px-4 py-2.5 text-xs font-mono text-slate-500">{time}</td>
+      <td className="px-4 py-2.5 text-sm text-slate-200">{ev.action}</td>
+      <td className="px-4 py-2.5 font-mono text-xs text-slate-400">{ev.source_ip}</td>
+      <td className="px-4 py-2.5 font-mono text-xs text-slate-300">{ev.username}</td>
+      <td className="px-4 py-2.5">
         <span className={`text-[10px] px-2 py-0.5 rounded-full border ${resultStyle[ev.result] ?? 'bg-slate-500/10 text-slate-400 border-slate-500/20'}`}>
           {ev.result}
         </span>
@@ -39,150 +265,96 @@ function EventRow({ ev }: { ev: SshEvent }) {
   )
 }
 
-export default function Security({ setView }: SecurityProps) {
-  const { data: servers } = useServers()
-  const serverId = servers?.[0]?.server_id ?? ''
-  const { data, isFetching, isError } = useSshEvents(serverId)
+// ── Main ──────────────────────────────────────────────────────────────────────
 
-  const stats = data?.stats
-  const events = data?.events ?? []
-  const blockedEvents = events.filter((e) => e.result === 'Blocked' || e.result === 'Dropped')
-  const successEvents = events.filter((e) => e.result === 'Success')
+export default function Security({ setView }: SecurityProps) {
+  const { t } = useTranslation()
+  const { data: servers } = useServers()
+  const selectedAgentId = useUIStore((s) => s.selectedAgentId)
+  const serverId = selectedAgentId ?? servers?.find((s) => s.status === 'online')?.server_id ?? servers?.[0]?.server_id ?? ''
+
+  const { data: sshData }      = useSshEvents(serverId)
+  const { data: attackersData } = useAttackers(serverId)
+  const { data: hourData }     = useAttackByHour(serverId)
+  const { data: baselineData } = useSshBaseline(serverId)
+
+  const stats    = sshData?.stats
+  const today    = stats?.attempts_24h ?? 0
+  const baseline = baselineData?.avg_daily ?? 0
+  const ratio    = baseline > 0 ? today / baseline : 0
+  const hourly   = hourData?.hours ?? Array.from({ length: 24 }, (_, i) => ({ hour: i, count: 0 }))
+  const peakHour = [...hourly].sort((a, b) => b.count - a.count)[0] ?? { hour: 0, count: 0 }
+
+  const severityState: HealthState = ratio > 2.5 ? 'critical' : ratio > 1.5 ? 'attention' : 'ok'
+  const attackers = attackersData?.attackers ?? []
+  const events    = sshData?.events ?? []
 
   return (
-    <Layout currentView="security" setView={setView} title="Segurança da Infraestrutura">
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+    <Layout currentView="security" setView={setView} title={t('security.title')}>
+      <div className="flex flex-col gap-6">
 
-        {/* Main column */}
-        <div className="lg:col-span-2 space-y-6">
+        {/* Threat hero */}
+        <ThreatHero
+          today={today}
+          baseline={baseline}
+          ratio={ratio}
+          state={severityState}
+          hourly={hourly}
+          peakHour={peakHour}
+        />
 
-          {/* Stats bar */}
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            <div className="glass-card p-4">
-              <p className="text-[10px] text-slate-500 uppercase tracking-widest mb-1">Tentativas / 1h</p>
-              <p className="text-2xl font-bold font-mono text-red-400">
-                {stats ? stats.attempts_1h.toLocaleString() : '—'}
-              </p>
-            </div>
-            <div className="glass-card p-4">
-              <p className="text-[10px] text-slate-500 uppercase tracking-widest mb-1">Tentativas / 24h</p>
-              <p className="text-2xl font-bold font-mono text-orange-400">
-                {stats ? stats.attempts_24h.toLocaleString() : '—'}
-              </p>
-            </div>
-            <div className="glass-card p-4">
-              <p className="text-[10px] text-slate-500 uppercase tracking-widest mb-1">IPs únicos / 24h</p>
-              <p className="text-2xl font-bold font-mono text-slate-200">
-                {stats ? stats.unique_ips_24h.toLocaleString() : '—'}
-              </p>
-            </div>
-            <div className="glass-card p-4">
-              <p className="text-[10px] text-slate-500 uppercase tracking-widest mb-1">Usuário mais visado</p>
-              <p className="text-lg font-bold font-mono text-brand-purple truncate">
-                {stats?.top_target ?? '—'}
-              </p>
-            </div>
-          </div>
+        {/* Two-column: attackers + side */}
+        <div className="grid gap-6" style={{ gridTemplateColumns: '2fr 1fr' }}>
 
-          {/* Audit log */}
+          {/* Attackers grouped by IP */}
           <div className="glass-card overflow-hidden">
-            <div className="p-4 border-b border-white/5 bg-white/5 flex items-center justify-between">
+            <div className="px-4 py-3 border-b border-white/5 bg-white/5 flex items-center justify-between">
               <h3 className="text-sm font-bold flex items-center gap-2">
-                <Eye className="w-4 h-4 text-brand-purple" />
-                Audit Log — SSH / Auth
+                <Users size={14} className="text-brand-purple" />
+                {t('security.attackers.title')}
               </h3>
-              <div className="flex items-center gap-2 text-xs text-slate-500">
-                {isFetching && <RefreshCw className="w-3 h-3 animate-spin" />}
-                <span>{events.length} eventos recentes</span>
-              </div>
+              <span className="text-[11px] font-mono text-slate-500">
+                {t('security.attackers.ips', { count: attackers.length })} · {attackers.reduce((s, a) => s + a.attempts, 0).toLocaleString()} attempts
+              </span>
             </div>
-
-            {isError && (
-              <p className="px-6 py-4 text-xs text-red-400">Erro ao carregar eventos de segurança.</p>
-            )}
-
-            {!isError && events.length === 0 && !isFetching && (
-              <p className="px-6 py-6 text-xs text-slate-500 text-center">Nenhum evento encontrado no auth.log.</p>
-            )}
-
-            {events.length > 0 && (
-              <div className="overflow-x-auto">
-                <table className="w-full text-left">
-                  <thead className="text-[10px] text-slate-500 uppercase tracking-widest bg-brand-dark/20">
-                    <tr>
-                      <th className="px-4 py-3 font-medium">Hora</th>
-                      <th className="px-4 py-3 font-medium">Evento</th>
-                      <th className="px-4 py-3 font-medium">IP Origem</th>
-                      <th className="px-4 py-3 font-medium">Usuário</th>
-                      <th className="px-4 py-3 font-medium">Status</th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-white/5">
-                    {events.map((ev, i) => <EventRow key={`${ev.timestamp}-${i}`} ev={ev} />)}
-                  </tbody>
-                </table>
-              </div>
-            )}
-          </div>
-        </div>
-
-        {/* Sidebar */}
-        <div className="space-y-6">
-
-          {/* Intrusion alert */}
-          <div className={`glass-card p-6 ${(stats?.attempts_1h ?? 0) > 0 ? 'border-red-500/20 bg-red-500/5' : 'border-brand-neon/20 bg-brand-neon/5'}`}>
-            <div className="flex items-center gap-3 mb-4">
-              {(stats?.attempts_1h ?? 0) > 0
-                ? <ShieldAlert className="w-6 h-6 text-red-500" />
-                : <ShieldCheck className="w-6 h-6 text-brand-neon" />
-              }
-              <h3 className={`font-bold ${(stats?.attempts_1h ?? 0) > 0 ? 'text-red-400' : 'text-brand-neon'}`}>
-                Alertas de Intrusão
-              </h3>
-            </div>
-            {stats ? (
-              <div className="space-y-2 text-xs text-slate-300">
-                {stats.attempts_1h > 0
-                  ? <p><span className="text-red-400 font-bold">{stats.attempts_1h}</span> tentativas na última hora</p>
-                  : <p className="text-brand-neon">Nenhuma tentativa na última hora.</p>
-                }
-                <p><span className="font-bold">{stats.attempts_24h}</span> tentativas nas últimas 24h</p>
-                <p><span className="font-bold">{stats.unique_ips_24h}</span> IPs distintos</p>
-                {stats.top_target && (
-                  <p>Alvo principal: <span className="font-mono text-brand-purple">{stats.top_target}</span></p>
-                )}
-              </div>
+            {attackers.length === 0 ? (
+              <p className="px-5 py-6 text-xs text-slate-500 text-center">No attackers detected in the last 24h.</p>
             ) : (
-              <p className="text-xs text-slate-500">Carregando...</p>
+              attackers.map((a) => <AttackerRow key={a.ip} attacker={a} />)
             )}
           </div>
 
-          {/* Session summary */}
-          <div className="glass-card p-6">
-            <h3 className="font-bold text-sm mb-4 flex items-center gap-2">
-              <ShieldCheck className="w-4 h-4 text-brand-purple" />
-              Resumo da Sessão
-            </h3>
-            <div className="space-y-3">
-              <div className="flex justify-between items-center text-xs">
-                <span className="text-slate-400">Bloqueios detectados</span>
-                <span className="font-mono font-bold text-red-400">{blockedEvents.length}</span>
-              </div>
-              <div className="flex justify-between items-center text-xs">
-                <span className="text-slate-400">Logins bem-sucedidos</span>
-                <span className="font-mono font-bold text-brand-neon">{successEvents.length}</span>
-              </div>
-              <div className="flex justify-between items-center text-xs">
-                <span className="text-slate-400">Servidor monitorado</span>
-                <span className="font-mono text-slate-300">{serverId || '—'}</span>
-              </div>
-              <div className="flex justify-between items-center text-xs">
-                <span className="text-slate-400">fail2ban</span>
-                <span className="text-[10px] text-brand-neon font-bold">● ACTIVE</span>
-              </div>
-            </div>
+          {/* Side: session + fail2ban */}
+          <div className="flex flex-col gap-4">
+            <SessionSummaryCard stats={stats} />
+            <Fail2BanCard />
           </div>
         </div>
+
+        {/* Audit log (detail) */}
+        {events.length > 0 && (
+          <div className="glass-card overflow-hidden">
+            <div className="px-4 py-3 border-b border-white/5 bg-white/5">
+              <h3 className="text-sm font-bold">Audit Log — SSH / Auth</h3>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full text-left">
+                <thead className="text-[10px] text-slate-500 uppercase tracking-widest bg-brand-dark/20">
+                  <tr>
+                    <th className="px-4 py-2 font-medium">Time</th>
+                    <th className="px-4 py-2 font-medium">Event</th>
+                    <th className="px-4 py-2 font-medium">Source IP</th>
+                    <th className="px-4 py-2 font-medium">User</th>
+                    <th className="px-4 py-2 font-medium">Result</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-white/5">
+                  {events.map((ev, i) => <EventRow key={`${ev.timestamp}-${i}`} ev={ev} />)}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
 
       </div>
     </Layout>

--- a/frontend/src/components/ServerDashboard.tsx
+++ b/frontend/src/components/ServerDashboard.tsx
@@ -1,11 +1,13 @@
-import React, { useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import ReactECharts from 'echarts-for-react'
 import * as echarts from 'echarts'
-import { ArrowLeft, RefreshCw, Activity } from 'lucide-react'
-import { useMetricNames, useMetricSeries, useAnomalyScores } from '../hooks/useMetrics'
-import MetricCard from './MetricCard'
+import { useTranslation } from 'react-i18next'
+import { ArrowLeft, RefreshCw, Activity, Server, Cpu, MemoryStick, HardDrive } from 'lucide-react'
+import { useMetricNames, useMetricSeries, useAnomalyScores, useHealthSnapshot } from '../hooks/useMetrics'
 import Layout from './Layout'
 import type { ViewType } from '../App'
+import { TrendBar, HealthScore } from './primitives'
+import type { HealthState } from './primitives'
 
 interface ServerDashboardProps {
   serverId: string
@@ -14,40 +16,51 @@ interface ServerDashboardProps {
 
 const TIME_RANGES = [
   { label: '15m', minutes: 15 },
-  { label: '1h', minutes: 60 },
-  { label: '6h', minutes: 360 },
+  { label: '1h',  minutes: 60 },
+  { label: '6h',  minutes: 360 },
   { label: '24h', minutes: 1440 },
 ]
 
-const METRIC_CONFIG: Record<string, { label: string; unit: string; color: string; thresholds?: { amber: number; red: number } }> = {
-  cpu_usage_percent:        { label: 'CPU',         unit: '%',      color: '#39FF14', thresholds: { amber: 70, red: 90 } },
-  memory_usage_percent:     { label: 'Memória',     unit: '%',      color: '#7C3AED', thresholds: { amber: 75, red: 90 } },
-  disk_usage_percent:       { label: 'Disco',       unit: '%',      color: '#F59E0B', thresholds: { amber: 80, red: 95 } },
-  disk_read_bytes_per_sec:  { label: 'Disco Leitura', unit: 'B/s', color: '#06B6D4' },
-  disk_write_bytes_per_sec: { label: 'Disco Escrita', unit: 'B/s', color: '#EC4899' },
-  net_bytes_recv_per_sec:   { label: 'Rede ↓',      unit: 'B/s',   color: '#10B981' },
-  net_bytes_sent_per_sec:   { label: 'Rede ↑',      unit: 'B/s',   color: '#F97316' },
-  process_count:            { label: 'Processos',   unit: '',       color: '#94A3B8' },
+const METRIC_CFG: Record<string, { label: string; unit: string; color: string; threshold?: number }> = {
+  cpu_usage_percent:        { label: 'CPU',           unit: '%',   color: '#39FF14', threshold: 80 },
+  memory_usage_percent:     { label: 'Memory',        unit: '%',   color: '#7C3AED', threshold: 90 },
+  disk_usage_percent:       { label: 'Disk',          unit: '%',   color: '#F59E0B', threshold: 95 },
+  disk_read_bytes_per_sec:  { label: 'Disk Read',     unit: 'B/s', color: '#06B6D4' },
+  disk_write_bytes_per_sec: { label: 'Disk Write',    unit: 'B/s', color: '#EC4899' },
+  net_bytes_recv_per_sec:   { label: 'Net ↓',         unit: 'B/s', color: '#10B981' },
+  net_bytes_sent_per_sec:   { label: 'Net ↑',         unit: 'B/s', color: '#F97316' },
+  process_count:            { label: 'Processes',     unit: '',    color: '#94A3B8' },
 }
 
-interface MetricChartProps {
+const TABS = ['health', 'io', 'processes'] as const
+type Tab = typeof TABS[number]
+
+const TAB_METRICS: Record<Tab, string[]> = {
+  health:    ['cpu_usage_percent', 'memory_usage_percent', 'disk_usage_percent'],
+  io:        ['disk_read_bytes_per_sec', 'disk_write_bytes_per_sec', 'net_bytes_recv_per_sec', 'net_bytes_sent_per_sec'],
+  processes: ['process_count'],
+}
+
+// ── Chart ─────────────────────────────────────────────────────────────────────
+
+function MetricChart({
+  serverId, metric, minutes, showAnomalies, threshold, baseline,
+}: {
   serverId: string
   metric: string
   minutes: number
-  showAnomalies?: boolean
-}
-
-const MetricChart: React.FC<MetricChartProps> = ({ serverId, metric, minutes, showAnomalies = false }) => {
+  showAnomalies: boolean
+  threshold?: number
+  baseline?: number | null
+}) {
   const { data, isFetching } = useMetricSeries(serverId, metric, minutes)
   const { data: anomalyData } = useAnomalyScores(serverId, metric, minutes, showAnomalies)
-  const cfg = METRIC_CONFIG[metric] ?? { label: metric, unit: '', color: '#94A3B8' }
+  const cfg = METRIC_CFG[metric] ?? { label: metric, unit: '', color: '#94A3B8' }
 
-  // Build sorted timestamp→value lookup for anomaly scatter positioning
   const metricLookup = useMemo(() => {
-    const entries = (data?.data ?? []).map(
-      (p) => [new Date(p.timestamp).getTime(), p.value] as [number, number]
-    )
-    return entries.sort((a, b) => a[0] - b[0])
+    return (data?.data ?? [])
+      .map((p) => [new Date(p.timestamp).getTime(), p.value] as [number, number])
+      .sort((a, b) => a[0] - b[0])
   }, [data])
 
   const nearestValue = (ts: string): number | null => {
@@ -64,7 +77,7 @@ const MetricChart: React.FC<MetricChartProps> = ({ serverId, metric, minutes, sh
   const anomalyPoints = useMemo(() => {
     if (!showAnomalies || !anomalyData) return { amber: [], red: [] }
     const amber: { value: [string, number]; score: number }[] = []
-    const red: { value: [string, number]; score: number }[] = []
+    const red:   { value: [string, number]; score: number }[] = []
     for (const a of anomalyData.data) {
       if (a.score < 0.5) continue
       const v = nearestValue(a.timestamp)
@@ -77,16 +90,20 @@ const MetricChart: React.FC<MetricChartProps> = ({ serverId, metric, minutes, sh
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [anomalyData, showAnomalies, metricLookup])
 
-  const scatterTooltip = {
-    trigger: 'item' as const,
-    formatter: (p: any) => {
-      const d = new Date(p.value[0])
-      const t = `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
-      return `${t}<br/>Anomalia: <b>${p.data.score.toFixed(2)}</b>`
-    },
-    backgroundColor: '#1E293B',
-    borderColor: '#EF4444',
-    textStyle: { color: '#F1F5F9', fontSize: 11 },
+  const markLines = []
+  if (threshold != null) {
+    markLines.push({
+      name: 'Threshold', yAxis: threshold,
+      lineStyle: { color: '#F87171', type: 'dashed', width: 1 },
+      label: { formatter: `${threshold}`, color: '#F87171', fontSize: 9 },
+    })
+  }
+  if (baseline != null) {
+    markLines.push({
+      name: 'Baseline', yAxis: baseline,
+      lineStyle: { color: 'rgba(255,255,255,0.25)', type: 'dotted', width: 1 },
+      label: { formatter: `${baseline}`, color: '#94A3B8', fontSize: 9 },
+    })
   }
 
   const option = {
@@ -101,16 +118,15 @@ const MetricChart: React.FC<MetricChartProps> = ({ serverId, metric, minutes, sh
         if (!line) return ''
         const d = new Date(line.value[0])
         const t = `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
-        return `${t}<br/>${line.seriesName}: ${line.value[1]}`
+        return `${t}<br/>${line.seriesName}: ${line.value[1]}${cfg.unit}`
       },
     },
-    grid: { left: '3%', right: '4%', bottom: '3%', top: '8%', containLabel: true },
+    grid: { left: '3%', right: '4%', bottom: '3%', top: '12%', containLabel: true },
     xAxis: {
       type: 'time',
       axisLine: { lineStyle: { color: '#334155' } },
       axisLabel: {
-        color: '#64748B',
-        fontSize: 10,
+        color: '#64748B', fontSize: 10,
         formatter: (value: number) => {
           const d = new Date(value)
           return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
@@ -136,29 +152,48 @@ const MetricChart: React.FC<MetricChartProps> = ({ serverId, metric, minutes, sh
           ]),
         },
         lineStyle: { width: 2, color: cfg.color },
+        markLine: markLines.length > 0
+          ? { silent: true, symbol: 'none', data: markLines }
+          : undefined,
       },
-      ...(showAnomalies
-        ? [
-            {
-              name: 'Anomalia média',
-              type: 'scatter',
-              data: anomalyPoints.amber,
-              symbolSize: 8,
-              itemStyle: { color: '#F59E0B', borderColor: '#78350F', borderWidth: 1 },
-              tooltip: scatterTooltip,
-              z: 10,
+      ...(showAnomalies ? [
+        {
+          name: 'Anomaly mid',
+          type: 'scatter',
+          data: anomalyPoints.amber,
+          symbolSize: 8,
+          itemStyle: { color: '#F59E0B', borderColor: '#78350F', borderWidth: 1 },
+          tooltip: {
+            trigger: 'item' as const,
+            formatter: (p: any) => {
+              const d = new Date(p.value[0])
+              const t = `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
+              return `${t}<br/>Anomaly: <b>${p.data.score.toFixed(2)}</b>`
             },
-            {
-              name: 'Anomalia alta',
-              type: 'scatter',
-              data: anomalyPoints.red,
-              symbolSize: 10,
-              itemStyle: { color: '#EF4444', borderColor: '#7F1D1D', borderWidth: 1 },
-              tooltip: scatterTooltip,
-              z: 11,
+            backgroundColor: '#1E293B', borderColor: '#F59E0B',
+            textStyle: { color: '#F1F5F9', fontSize: 11 },
+          },
+          z: 10,
+        },
+        {
+          name: 'Anomaly high',
+          type: 'scatter',
+          data: anomalyPoints.red,
+          symbolSize: 10,
+          itemStyle: { color: '#EF4444', borderColor: '#7F1D1D', borderWidth: 1 },
+          tooltip: {
+            trigger: 'item' as const,
+            formatter: (p: any) => {
+              const d = new Date(p.value[0])
+              const t = `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
+              return `${t}<br/>Anomaly: <b>${p.data.score.toFixed(2)}</b>`
             },
-          ]
-        : []),
+            backgroundColor: '#1E293B', borderColor: '#EF4444',
+            textStyle: { color: '#F1F5F9', fontSize: 11 },
+          },
+          z: 11,
+        },
+      ] : []),
     ],
   }
 
@@ -175,30 +210,143 @@ const MetricChart: React.FC<MetricChartProps> = ({ serverId, metric, minutes, sh
   )
 }
 
-const ServerDashboard: React.FC<ServerDashboardProps> = ({ serverId, setView }) => {
+// ── Narrative hero ────────────────────────────────────────────────────────────
+
+function NarrativeHero({ serverId }: { serverId: string }) {
+  const { t } = useTranslation()
+  const { data: snap, isLoading } = useHealthSnapshot(serverId)
+
+  if (isLoading || !snap) {
+    return (
+      <div className="glass-card p-6 mb-6 flex items-center gap-3 text-slate-500 text-sm">
+        <RefreshCw className="w-4 h-4 animate-spin" />
+        <span>{t('common.loading')}</span>
+      </div>
+    )
+  }
+
+  const state = snap.state as HealthState
+  const metricRows = [
+    { key: 'cpu',    label: t('health.metrics.cpu'),    icon: Cpu,         metric: snap.cpu,    color: '#39FF14' },
+    { key: 'memory', label: t('health.metrics.memory'), icon: MemoryStick, metric: snap.memory, color: '#7C3AED' },
+    { key: 'disk',   label: t('health.metrics.disk'),   icon: HardDrive,   metric: snap.disk,   color: '#F59E0B' },
+  ]
+
+  return (
+    <div className="glass-card p-5 mb-6">
+      {/* Header row */}
+      <div className="flex items-start gap-4 mb-5">
+        <div className="w-10 h-10 rounded-xl bg-brand-slate flex items-center justify-center flex-shrink-0">
+          <Server className="w-5 h-5 text-brand-purple" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-3 flex-wrap">
+            <h2 className="font-mono text-base font-bold text-slate-100">{serverId}</h2>
+            <HealthScore state={state} size="sm" />
+          </div>
+          {snap.headline && (
+            <p className="text-sm text-slate-300 mt-1 leading-relaxed">{snap.headline}</p>
+          )}
+        </div>
+        {snap.anomalies6h > 0 && (
+          <span className="text-[11px] font-mono text-amber-400 bg-amber-400/10 border border-amber-400/20 px-2 py-1 rounded-md shrink-0">
+            {t('health.anomalies6h', { count: snap.anomalies6h })}
+          </span>
+        )}
+      </div>
+
+      {/* Metric bars */}
+      <div className="space-y-3">
+        {metricRows.map(({ key, label, icon: Icon, metric, color }) => {
+          if (!metric || metric.value == null) return null
+          const over = metric.value >= metric.threshold * 0.9
+          return (
+            <div key={key} className="grid items-center gap-x-3" style={{ gridTemplateColumns: '20px 56px 1fr auto' }}>
+              <Icon size={12} className="text-slate-500" />
+              <span className="text-[10px] font-bold uppercase tracking-widest text-slate-500">{label}</span>
+              <TrendBar
+                value={metric.value}
+                threshold={metric.threshold}
+                baseline={metric.baseline ?? undefined}
+                color={color}
+                height={5}
+              />
+              <span className={`font-mono text-xs font-bold text-right ${over ? 'text-red-400' : 'text-slate-200'}`}
+                    style={{ minWidth: 40 }}>
+                {metric.value}%
+              </span>
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Critical services */}
+      {snap.critical_services.length > 0 && (
+        <div className="flex items-center gap-2 mt-4 pt-3 border-t border-white/5 flex-wrap">
+          <span className="text-[10px] text-slate-500 uppercase tracking-widest">{t('common.criticalServices')}</span>
+          {snap.critical_services.slice(0, 8).map((svc) => (
+            <div
+              key={svc.name}
+              title={`${svc.name} · ${svc.ok ? 'active' : 'failed'}`}
+              className="flex items-center gap-1"
+            >
+              <div style={{
+                width: 6, height: 6, borderRadius: '50%',
+                background: svc.ok ? '#39FF14' : '#F87171',
+                boxShadow: svc.ok ? '0 0 4px rgba(57,255,20,0.5)' : 'none',
+              }} />
+              <span className="text-[10px] text-slate-500">{svc.name}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+export default function ServerDashboard({ serverId, setView }: ServerDashboardProps) {
+  const { t } = useTranslation()
   const [minutes, setMinutes] = useState(60)
   const [showAnomalies, setShowAnomalies] = useState(false)
-  const { data: metricNames } = useMetricNames(serverId)
+  const [activeTab, setActiveTab] = useState<Tab>('health')
 
-  const summaryMetrics = ['cpu_usage_percent', 'memory_usage_percent', 'disk_usage_percent', 'process_count']
-  const chartMetrics = metricNames?.metrics ?? Object.keys(METRIC_CONFIG)
+  const { data: metricNames } = useMetricNames(serverId)
+  const { data: snap } = useHealthSnapshot(serverId)
+  const available = new Set(metricNames?.metrics ?? [])
+
+  const baselines: Record<string, number | null> = {
+    cpu_usage_percent:    snap?.cpu?.baseline    ?? null,
+    memory_usage_percent: snap?.memory?.baseline ?? null,
+    disk_usage_percent:   snap?.disk?.baseline   ?? null,
+  }
+
+  const tabMetrics = TAB_METRICS[activeTab].filter(
+    (m) => available.size === 0 || available.has(m)
+  )
+
+  const tabLabel: Record<Tab, string> = {
+    health:    t('server.tabs.health'),
+    io:        t('server.tabs.io'),
+    processes: t('server.tabs.processes'),
+  }
 
   return (
     <Layout currentView="infrastructure" setView={setView} title={serverId}>
       <div className="space-y-6">
-        {/* Header */}
-        <div className="flex items-center justify-between">
+        {/* Back + controls */}
+        <div className="flex items-center justify-between flex-wrap gap-3">
           <button
             onClick={() => setView('infrastructure')}
             className="flex items-center gap-2 text-sm text-slate-400 hover:text-slate-200 transition-colors"
           >
             <ArrowLeft className="w-4 h-4" />
-            Servidores
+            {t('infrastructure.title')}
           </button>
           <div className="flex items-center gap-2">
             <button
               onClick={() => setShowAnomalies((v) => !v)}
-              title="Exibir pontos de anomalia nos gráficos"
               className={`flex items-center gap-1.5 px-3 py-1 text-xs font-mono rounded border transition-colors ${
                 showAnomalies
                   ? 'bg-brand-purple/20 border-brand-purple/50 text-brand-purple'
@@ -206,7 +354,7 @@ const ServerDashboard: React.FC<ServerDashboardProps> = ({ serverId, setView }) 
               }`}
             >
               <Activity className="w-3 h-3" />
-              Anomalias
+              {t('server.anomalySummary')}
             </button>
             <div className="flex gap-1">
               {TIME_RANGES.map((r) => (
@@ -226,37 +374,44 @@ const ServerDashboard: React.FC<ServerDashboardProps> = ({ serverId, setView }) 
           </div>
         </div>
 
-        {/* Summary Cards (#16) */}
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          {summaryMetrics.map((metric) => (
-            <SummaryCardWrapper key={metric} serverId={serverId} metric={metric} minutes={minutes} />
+        {/* Narrative hero */}
+        <NarrativeHero serverId={serverId} />
+
+        {/* Tabs */}
+        <div className="flex gap-1 border-b border-white/10 pb-0">
+          {TABS.map((tab) => (
+            <button
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              className={`px-4 py-2 text-xs font-bold uppercase tracking-widest rounded-t transition-colors ${
+                activeTab === tab
+                  ? 'text-brand-purple border-b-2 border-brand-purple bg-brand-purple/5'
+                  : 'text-slate-500 hover:text-slate-300'
+              }`}
+            >
+              {tabLabel[tab]}
+            </button>
           ))}
         </div>
 
-        {/* Charts (#15) */}
+        {/* Charts grid */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-          {chartMetrics.map((metric) => (
-            <MetricChart key={metric} serverId={serverId} metric={metric} minutes={minutes} showAnomalies={showAnomalies} />
+          {tabMetrics.map((metric) => (
+            <MetricChart
+              key={metric}
+              serverId={serverId}
+              metric={metric}
+              minutes={minutes}
+              showAnomalies={showAnomalies}
+              threshold={METRIC_CFG[metric]?.threshold}
+              baseline={baselines[metric]}
+            />
           ))}
+          {tabMetrics.length === 0 && (
+            <p className="text-slate-500 text-sm lg:col-span-2">{t('common.noData')}</p>
+          )}
         </div>
       </div>
     </Layout>
   )
 }
-
-const SummaryCardWrapper: React.FC<{ serverId: string; metric: string; minutes: number }> = ({
-  serverId, metric, minutes,
-}) => {
-  const { data } = useMetricSeries(serverId, metric, minutes)
-  const cfg = METRIC_CONFIG[metric] ?? { label: metric, unit: '', color: '#94A3B8' }
-  return (
-    <MetricCard
-      label={cfg.label}
-      unit={cfg.unit}
-      data={data?.data ?? []}
-      thresholds={(cfg as typeof METRIC_CONFIG[string]).thresholds}
-    />
-  )
-}
-
-export default ServerDashboard

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useTranslation } from 'react-i18next'
 import {
     Terminal,
     Shield,
@@ -17,14 +17,15 @@ interface SidebarProps {
 }
 
 const Sidebar: React.FC<SidebarProps> = ({ currentView, setView }) => {
+    const { t } = useTranslation()
     const username = useAuthStore((s) => s.username)
     const logout = useAuthStore((s) => s.logout)
     const menuItems: { icon: any, label: string, id: ViewType }[] = [
-        { icon: LayoutDashboard, label: 'Dashboards', id: 'dashboard' },
-        { icon: Terminal, label: 'Syslogs Explorer', id: 'logs' },
-        { icon: Server, label: 'Infrastructure', id: 'infrastructure' },
-        { icon: Shield, label: 'Security & Auth', id: 'security' },
-        { icon: Bell, label: 'Alerts & Incidents', id: 'alerts' },
+        { icon: LayoutDashboard, label: t('nav.dashboard'),      id: 'dashboard' },
+        { icon: Terminal,        label: t('nav.logs'),            id: 'logs' },
+        { icon: Server,          label: t('nav.infrastructure'),  id: 'infrastructure' },
+        { icon: Shield,          label: t('nav.security'),        id: 'security' },
+        { icon: Bell,            label: t('nav.alerts'),          id: 'alerts' },
     ];
 
     return (
@@ -58,7 +59,7 @@ const Sidebar: React.FC<SidebarProps> = ({ currentView, setView }) => {
                         {username?.[0]?.toUpperCase() ?? '?'}
                     </div>
                     <div className="flex flex-col overflow-hidden flex-1 min-w-0">
-                        <span className="text-[10px] text-slate-500 uppercase tracking-widest font-bold">Conectado como</span>
+                        <span className="text-[10px] text-slate-500 uppercase tracking-widest font-bold">{t('nav.connectedAs')}</span>
                         <span className="text-sm font-semibold truncate font-mono">{username ?? '—'}</span>
                     </div>
                 </div>
@@ -67,7 +68,7 @@ const Sidebar: React.FC<SidebarProps> = ({ currentView, setView }) => {
                     className="flex items-center gap-2 w-full px-3 py-2 rounded-lg text-slate-500 hover:text-red-400 hover:bg-red-500/10 transition-all text-xs font-medium"
                 >
                     <LogOut className="w-3.5 h-3.5" />
-                    Sair
+                    {t('nav.logout')}
                 </button>
             </div>
         </aside>

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -4,7 +4,9 @@
     "infrastructure": "Infrastructure",
     "security": "Security",
     "alerts": "Alerts",
-    "logs": "Logs"
+    "logs": "Logs",
+    "connectedAs": "Connected as",
+    "logout": "Log out"
   },
   "common": {
     "loading": "Loading…",
@@ -164,6 +166,15 @@
     "liveLabel": "LIVE",
     "pauseLabel": "PAUSE",
     "clearLabel": "CLEAR",
-    "noLogs": "No logs yet — select a file above."
+    "noLogs": "No logs yet — select a file above.",
+    "server": "Server",
+    "files": "Files",
+    "filterPlaceholder": "Filter lines…",
+    "export": "Export",
+    "noLogsAvailable": "No logs available",
+    "selectServer": "Select a server",
+    "selectFiles": "Select one or more log files",
+    "watchingFiles": "Watching {{count}} file(s) on {{server}}",
+    "ready": "Ready"
   }
 }

--- a/frontend/src/i18n/locales/pt-BR/common.json
+++ b/frontend/src/i18n/locales/pt-BR/common.json
@@ -4,7 +4,9 @@
     "infrastructure": "Infraestrutura",
     "security": "Segurança",
     "alerts": "Alertas",
-    "logs": "Logs"
+    "logs": "Logs",
+    "connectedAs": "Conectado como",
+    "logout": "Sair"
   },
   "common": {
     "loading": "Carregando…",
@@ -164,6 +166,15 @@
     "liveLabel": "AO VIVO",
     "pauseLabel": "PAUSAR",
     "clearLabel": "LIMPAR",
-    "noLogs": "Nenhum log ainda — selecione um arquivo acima."
+    "noLogs": "Nenhum log ainda — selecione um arquivo acima.",
+    "server": "Servidor",
+    "files": "Arquivos",
+    "filterPlaceholder": "Filtrar linhas…",
+    "export": "Exportar",
+    "noLogsAvailable": "Nenhum log disponível",
+    "selectServer": "Selecione um servidor",
+    "selectFiles": "Selecione um ou mais arquivos de log",
+    "watchingFiles": "Monitorando {{count}} arquivo(s) em {{server}}",
+    "ready": "Pronto"
   }
 }


### PR DESCRIPTION
## Summary

- **Dashboard V2**: `FleetTallyDot` overview, `FocusHero` with NarrativeBlock, `MetricBlock` with Sparkline, `IncidentsCard`, `AnomaliesCard`, `FleetTile` per server, `SecurityPulseCard`
- **Infrastructure V2**: `SnapshotCard` with TrendBar meters, state color stripe, parallel health snapshots via `useQueries`
- **Security V2**: `ThreatHero` with hourly bar chart + 7d baseline overlay, collapsible `AttackerRow`, `SessionSummaryCard`, `Fail2BanCard`
- **Alerts V2**: `LivingRuleCard` with TrendBar (current value vs threshold), state pill (FIRING/ACTIVE/QUIET/DORMANT), pattern footer (fires7d, peak_window), `AlertsHero` summary strip
- **ServerDashboard V2**: `NarrativeHero` using health-snapshot (headline + TrendBars + critical services), tabbed layout (Health / I/O / Processes), ECharts with threshold + baseline markLines
- **i18n complete**: Sidebar, LogsExplorer fully translated; `nav.connectedAs`, `nav.logout`, `logs.*` keys added to both locales

## Components Changed

- [x] Frontend (React)

## Test Plan

- [x] `npm run type-check` passing (clean)
- [ ] Manual: Dashboard shows fleet overview and focus server
- [ ] Manual: Infrastructure cards show metric bars per server
- [ ] Manual: Security shows attack bars and attacker list
- [ ] Manual: Alerts shows living rule cards with current values
- [ ] Manual: ServerDashboard tabs switch correctly, threshold lines visible
- [ ] Manual: Language toggle switches EN ↔ PT-BR in all components

## Notes

This sprint completes the full V2 frontend redesign. All components now use the health-snapshot, attackers, attack-by-hour, ssh-baseline, and rule-patterns endpoints added in PR #65.

Closes #63